### PR TITLE
feat: add entry check/fix/remove commands with shared EntryRef type

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
 use archelon_core::{
+    entry_ref::EntryRef,
     journal::Journal,
     ops::{self, EntryFields as CoreEntryFields, EntryFilter, MatchLabel},
     period::{parse_datetime, parse_datetime_end, parse_period},
@@ -88,6 +89,21 @@ pub enum EntryCommand {
         #[command(flatten)]
         fields: EntryFields,
     },
+    /// Check whether an entry's frontmatter and filename are valid
+    Check {
+        /// Path to the entry file, or an ID / ID prefix
+        entry: String,
+    },
+    /// Rename an entry file to match its frontmatter ID and title/slug
+    Fix {
+        /// Path to the entry file, or an ID / ID prefix
+        entry: String,
+    },
+    /// Delete an entry file
+    Remove {
+        /// Path to the entry file, or an ID / ID prefix
+        entry: String,
+    },
 }
 
 /// Frontmatter fields shared between `entry new` and `entry set` (clap-aware).
@@ -172,6 +188,9 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
         EntryCommand::New { name, body, fields } => new(journal_dir, &name, body, fields),
         EntryCommand::Edit { entry } => edit(&resolve_entry(journal_dir, &entry)?),
         EntryCommand::Set { entry, fields } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields),
+        EntryCommand::Check { entry } => check(journal_dir, &entry),
+        EntryCommand::Fix { entry } => fix(journal_dir, &entry),
+        EntryCommand::Remove { entry } => remove(journal_dir, &entry),
     }
 }
 
@@ -347,15 +366,49 @@ fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<(
     Ok(())
 }
 
+// ── check ─────────────────────────────────────────────────────────────────────
+
+fn check(journal_dir: Option<&Path>, entry: &str) -> Result<()> {
+    let path = resolve_entry(journal_dir, entry)?;
+    let issues = ops::check_entry(&path)?;
+    if issues.is_empty() {
+        println!("ok: {}", path.display());
+    } else {
+        for issue in &issues {
+            println!("{}: {}", path.display(), issue.as_str());
+        }
+    }
+    Ok(())
+}
+
+// ── fix ───────────────────────────────────────────────────────────────────────
+
+fn fix(journal_dir: Option<&Path>, entry: &str) -> Result<()> {
+    let path = resolve_entry(journal_dir, entry)?;
+    match ops::fix_entry(&path)? {
+        Some(new_path) => println!(
+            "renamed: {} → {}",
+            path.file_name().unwrap_or_default().to_string_lossy(),
+            new_path.file_name().unwrap_or_default().to_string_lossy(),
+        ),
+        None => println!("ok: {} (already correct)", path.display()),
+    }
+    Ok(())
+}
+
+// ── remove ────────────────────────────────────────────────────────────────────
+
+fn remove(journal_dir: Option<&Path>, entry: &str) -> Result<()> {
+    let path = resolve_entry(journal_dir, entry)?;
+    ops::remove_entry(&path)?;
+    println!("removed: {}", path.display());
+    Ok(())
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 fn resolve_entry(journal_dir: Option<&Path>, entry: &str) -> Result<PathBuf> {
-    let p = Path::new(entry);
-    if p.exists() {
-        return Ok(p.to_path_buf());
-    }
-    let journal = open_journal(journal_dir)?;
-    journal.find_entry_by_id(entry).map_err(Into::into)
+    ops::resolve_entry(&EntryRef::parse(entry), journal_dir).map_err(Into::into)
 }
 
 fn resolve_editor() -> String {

--- a/archelon-core/src/entry_ref.rs
+++ b/archelon-core/src/entry_ref.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+use crate::{error::Result, journal::Journal};
+
+/// A reference to a journal entry — either a filesystem path or a CarettaId prefix.
+///
+/// This is the canonical input type for commands that operate on a single entry
+/// (show, fix, remove, etc.).  Parse raw user input with [`EntryRef::parse`], then
+/// resolve it to a concrete [`PathBuf`] with [`EntryRef::resolve`].
+#[derive(Debug, Clone)]
+pub enum EntryRef {
+    /// A filesystem path to the entry file.
+    Path(PathBuf),
+    /// A CarettaId prefix (1–7 characters).
+    Id(String),
+}
+
+impl EntryRef {
+    /// Classify a raw string as a path or an ID prefix.
+    ///
+    /// The string is treated as a **path** when it:
+    /// - contains a path separator (`/` or the platform separator), or
+    /// - starts with `.` or `~`, or
+    /// - ends with `.md`.
+    ///
+    /// Everything else is treated as a **CarettaId prefix**.
+    pub fn parse(s: &str) -> Self {
+        if s.contains('/')
+            || s.contains(std::path::MAIN_SEPARATOR)
+            || s.starts_with('.')
+            || s.ends_with(".md")
+        {
+            EntryRef::Path(PathBuf::from(s))
+        } else {
+            EntryRef::Id(s.to_owned())
+        }
+    }
+
+    /// Resolve this reference to a concrete file path.
+    ///
+    /// - `Path` variant: returns the stored path as-is.
+    /// - `Id` variant: delegates to [`Journal::find_entry_by_id`].
+    pub fn resolve(&self, journal: &Journal) -> Result<PathBuf> {
+        match self {
+            EntryRef::Path(p) => Ok(p.clone()),
+            EntryRef::Id(id) => journal.find_entry_by_id(id),
+        }
+    }
+}
+
+impl From<&str> for EntryRef {
+    fn from(s: &str) -> Self {
+        Self::parse(s)
+    }
+}
+
+impl From<String> for EntryRef {
+    fn from(s: String) -> Self {
+        Self::parse(&s)
+    }
+}

--- a/archelon-core/src/lib.rs
+++ b/archelon-core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod entry;
+pub mod entry_ref;
 pub mod error;
 pub mod journal;
 pub mod ops;

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -6,12 +6,14 @@
 
 use std::path::{Path, PathBuf};
 
+use caretta_id::CarettaId;
 use chrono::NaiveDateTime;
 
 use crate::{
     entry::{Entry, EventMeta, Frontmatter, TaskMeta},
+    entry_ref::EntryRef,
     error::{Error, Result},
-    journal::{is_managed_filename, Journal, new_entry_path},
+    journal::{is_managed_filename, Journal, new_entry_path, slugify},
     parser::{read_entry, render_entry, write_entry},
     period::Period,
 };
@@ -339,4 +341,126 @@ pub fn update_entry(path: &Path, fields: EntryFields) -> Result<()> {
 
     write_entry(&mut entry)?;
     Ok(())
+}
+
+// ── EntryRef resolution ───────────────────────────────────────────────────────
+
+/// Resolve an [`EntryRef`] to a concrete path, opening the journal when needed.
+///
+/// - `Path` variant: returned as-is.
+/// - `Id` variant: searches the journal found via `journal_dir` (or auto-detected).
+pub fn resolve_entry(entry_ref: &EntryRef, journal_dir: Option<&Path>) -> Result<PathBuf> {
+    match entry_ref {
+        EntryRef::Path(p) => Ok(p.clone()),
+        EntryRef::Id(id) => {
+            let journal = if let Some(dir) = journal_dir {
+                Journal::from_root(dir.to_path_buf())?
+            } else {
+                Journal::find()?
+            };
+            journal.find_entry_by_id(id)
+        }
+    }
+}
+
+// ── CheckIssue ────────────────────────────────────────────────────────────────
+
+/// A problem reported by [`check_entry`].
+#[derive(Debug, Clone)]
+pub enum CheckIssue {
+    /// The file does not follow the archelon-managed filename convention.
+    UnmanagedFilename,
+    /// The filename does not match the ID + title/slug derived from the frontmatter.
+    FilenameMismatch {
+        /// The filename the entry *should* have.
+        expected_filename: String,
+    },
+}
+
+impl CheckIssue {
+    pub fn as_str(&self) -> String {
+        match self {
+            CheckIssue::UnmanagedFilename =>
+                "not a managed entry (filename lacks a valid CarettaId prefix)".to_owned(),
+            CheckIssue::FilenameMismatch { expected_filename } =>
+                format!("filename mismatch — should be `{expected_filename}`"),
+        }
+    }
+}
+
+// ── check ─────────────────────────────────────────────────────────────────────
+
+/// Validate an entry's frontmatter and filename.
+///
+/// Returns a (possibly empty) list of [`CheckIssue`]s.
+/// An empty list means the entry passes all checks.
+pub fn check_entry(path: &Path) -> Result<Vec<CheckIssue>> {
+    if !is_managed_filename(path) {
+        return Ok(vec![CheckIssue::UnmanagedFilename]);
+    }
+
+    let entry = read_entry(path)?;
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
+    // Safety: `is_managed_filename` guarantees a valid 7-char CarettaId prefix.
+    let id: CarettaId = stem[..7].parse().unwrap();
+    let expected = entry_filename_from_frontmatter(id, &entry.frontmatter);
+    let actual = path.file_name().and_then(|s| s.to_str()).unwrap_or_default();
+
+    let mut issues = Vec::new();
+    if actual != expected {
+        issues.push(CheckIssue::FilenameMismatch { expected_filename: expected });
+    }
+    Ok(issues)
+}
+
+// ── fix ───────────────────────────────────────────────────────────────────────
+
+/// Rename an entry file so its name matches the frontmatter ID and title/slug.
+///
+/// Returns `Some(new_path)` if the file was renamed, `None` if it was already correct.
+/// Returns `Err` if the file is not a managed entry.
+pub fn fix_entry(path: &Path) -> Result<Option<PathBuf>> {
+    if !is_managed_filename(path) {
+        return Err(Error::InvalidEntry(format!(
+            "{}: not a managed entry (filename lacks a valid CarettaId prefix)",
+            path.display()
+        )));
+    }
+
+    let entry = read_entry(path)?;
+    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
+    let id: CarettaId = stem[..7].parse().unwrap();
+
+    let expected = entry_filename_from_frontmatter(id, &entry.frontmatter);
+    let actual = path.file_name().and_then(|s| s.to_str()).unwrap_or_default();
+
+    if actual == expected {
+        return Ok(None);
+    }
+
+    let new_path = path.parent().unwrap_or_else(|| Path::new(".")).join(&expected);
+    std::fs::rename(path, &new_path)?;
+    Ok(Some(new_path))
+}
+
+// ── remove ────────────────────────────────────────────────────────────────────
+
+/// Delete an entry file from disk.
+pub fn remove_entry(path: &Path) -> Result<()> {
+    std::fs::remove_file(path).map_err(Error::Io)
+}
+
+// ── internal helpers ──────────────────────────────────────────────────────────
+
+/// Build the canonical filename for an entry using the frontmatter slug (if set)
+/// or `slugify(title)` as a fallback.
+fn entry_filename_from_frontmatter(id: CarettaId, fm: &Frontmatter) -> String {
+    let slug = fm.slug.clone().unwrap_or_else(|| {
+        fm.title.as_deref().map(slugify).unwrap_or_default()
+    });
+    if slug.is_empty() {
+        format!("{id}.md")
+    } else {
+        format!("{id}_{slug}.md")
+    }
 }

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context as _;
 use archelon_core::{
+    entry_ref::EntryRef,
     journal::{Journal, WeekStart},
     ops::{self, EntryFields, EntryFilter},
     parser::read_entry,
@@ -42,12 +43,8 @@ impl ArchelonServer {
     }
 
     fn resolve_entry(&self, entry: &str) -> anyhow::Result<PathBuf> {
-        let p = Path::new(entry);
-        if p.exists() {
-            return Ok(p.to_path_buf());
-        }
-        let journal = self.open_journal()?;
-        journal.find_entry_by_id(entry).map_err(Into::into)
+        ops::resolve_entry(&EntryRef::parse(entry), self.journal_dir.as_deref())
+            .map_err(Into::into)
     }
 
     fn week_start(&self) -> WeekStart {
@@ -145,6 +142,24 @@ struct EntrySetParams {
     event_start: Option<String>,
     /// Event end date/time (YYYY-MM-DD or YYYY-MM-DDTHH:MM)
     event_end: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct EntryCheckParams {
+    /// File path to the entry, or an ID / ID prefix
+    entry: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct EntryFixParams {
+    /// File path to the entry, or an ID / ID prefix
+    entry: String,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct EntryRemoveParams {
+    /// File path to the entry, or an ID / ID prefix
+    entry: String,
 }
 
 // ── helpers for parameter parsing ─────────────────────────────────────────────
@@ -367,6 +382,52 @@ impl ArchelonServer {
             )?;
             ops::update_entry(&path, fields)?;
             Ok(format!("updated: {}", path.display()))
+        })()
+        .map_err(|e| e.to_string())
+    }
+
+    #[tool(description = "Check whether an entry's frontmatter and filename are valid. \
+        Returns 'ok' or a list of issues (e.g. filename mismatch).")]
+    fn entry_check(&self, Parameters(p): Parameters<EntryCheckParams>) -> Result<String, String> {
+        (|| -> anyhow::Result<String> {
+            let path = self.resolve_entry(&p.entry)?;
+            let issues = ops::check_entry(&path)?;
+            if issues.is_empty() {
+                Ok(format!("ok: {}", path.display()))
+            } else {
+                let lines: Vec<String> = issues
+                    .iter()
+                    .map(|i| format!("{}: {}", path.display(), i.as_str()))
+                    .collect();
+                Ok(lines.join("\n"))
+            }
+        })()
+        .map_err(|e| e.to_string())
+    }
+
+    #[tool(description = "Rename an entry file so its name matches the frontmatter ID and title/slug. \
+        Reports the rename or confirms the filename is already correct.")]
+    fn entry_fix(&self, Parameters(p): Parameters<EntryFixParams>) -> Result<String, String> {
+        (|| -> anyhow::Result<String> {
+            let path = self.resolve_entry(&p.entry)?;
+            match ops::fix_entry(&path)? {
+                Some(new_path) => Ok(format!(
+                    "renamed: {} → {}",
+                    path.file_name().unwrap_or_default().to_string_lossy(),
+                    new_path.file_name().unwrap_or_default().to_string_lossy(),
+                )),
+                None => Ok(format!("ok: {} (already correct)", path.display())),
+            }
+        })()
+        .map_err(|e| e.to_string())
+    }
+
+    #[tool(description = "Delete an entry file from the journal")]
+    fn entry_remove(&self, Parameters(p): Parameters<EntryRemoveParams>) -> Result<String, String> {
+        (|| -> anyhow::Result<String> {
+            let path = self.resolve_entry(&p.entry)?;
+            ops::remove_entry(&path)?;
+            Ok(format!("removed: {}", path.display()))
         })()
         .map_err(|e| e.to_string())
     }


### PR DESCRIPTION
- archelon-core: add `entry_ref::EntryRef` enum for unified ID-or-path argument parsing across CLI and MCP
- archelon-core/ops: add `resolve_entry`, `check_entry`, `fix_entry`, `remove_entry` operations
- archelon-cli: add `entry check`, `entry fix`, `entry remove` subcommands; replace local resolve_entry helper with ops::resolve_entry
- archelon-mcp: add `entry_check`, `entry_fix`, `entry_remove` tools; replace local resolve_entry with ops::resolve_entry