### PR TITLE
feat: add required id field to Frontmatter

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -215,7 +215,7 @@ fn print_entries(
             .iter()
             .map(|(entry, labels)| {
                 let mut v = serde_json::json!({
-                    "id": entry.id().map(|id| id.to_string()),
+                    "id": entry.id().to_string(),
                     "path": entry.path.display().to_string(),
                     "title": entry.title(),
                     "slug": entry.frontmatter.slug,
@@ -241,7 +241,7 @@ fn print_entries(
     let rows: Vec<(String, String, String)> = entries
         .iter()
         .map(|(entry, labels)| {
-            let id = entry.id().map(|id| id.to_string()).unwrap_or_default();
+            let id = entry.id().to_string();
             let status = if has_filter && !labels.is_empty() {
                 labels.iter().map(|l| l.as_str()).collect::<Vec<_>>().join(",")
             } else {

--- a/archelon-core/Cargo.toml
+++ b/archelon-core/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-caretta-id = "0.11.0-rc.2"
+caretta-id = { version = "0.11.0-rc.2", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 toml = "0.8"

--- a/archelon-core/src/entry.rs
+++ b/archelon-core/src/entry.rs
@@ -4,8 +4,10 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Frontmatter metadata stored at the top of each .md file.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Frontmatter {
+    pub id: CarettaId,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 
@@ -35,13 +37,7 @@ pub struct Frontmatter {
 
 impl Frontmatter {
     pub fn is_empty(&self) -> bool {
-        self.title.is_none()
-            && self.slug.is_none()
-            && self.created_at.is_none()
-            && self.updated_at.is_none()
-            && self.tags.is_empty()
-            && self.task.is_none()
-            && self.event.is_none()
+        false
     }
 }
 
@@ -90,11 +86,9 @@ pub struct Entry {
 }
 
 impl Entry {
-    /// Returns the CarettaId parsed from the first 7 characters of the file stem,
-    /// or `None` if the filename does not follow the `{id}_{slug}.md` convention.
-    pub fn id(&self) -> Option<CarettaId> {
-        let stem = self.path.file_stem()?.to_str()?;
-        stem.get(..7)?.parse().ok()
+    /// Returns the CarettaId from the frontmatter.
+    pub fn id(&self) -> CarettaId {
+        self.frontmatter.id
     }
 
     /// Returns the title: frontmatter title → file stem → "(untitled)".

--- a/archelon-core/src/journal.rs
+++ b/archelon-core/src/journal.rs
@@ -218,10 +218,13 @@ pub fn entry_filename(id: CarettaId, title: &str) -> String {
 ///
 /// The ID is based on the current Unix time (`CarettaId::now_unix()`), so
 /// filenames sort chronologically within a year directory.
-pub fn new_entry_path(title: &str) -> PathBuf {
+///
+/// Returns `(relative_path, id)` so the caller can embed the ID in frontmatter.
+pub fn new_entry_path(title: &str) -> (PathBuf, CarettaId) {
     let id = CarettaId::now_unix();
     let year = chrono::Local::now().year();
-    PathBuf::from(year.to_string()).join(entry_filename(id, title))
+    let path = PathBuf::from(year.to_string()).join(entry_filename(id, title));
+    (path, id)
 }
 
 #[cfg(test)]

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -7,13 +7,13 @@
 use std::path::{Path, PathBuf};
 
 use caretta_id::CarettaId;
-use chrono::NaiveDateTime;
+use chrono::{Datelike as _, NaiveDateTime};
 
 use crate::{
     entry::{Entry, EventMeta, Frontmatter, TaskMeta},
     entry_ref::EntryRef,
     error::{Error, Result},
-    journal::{is_managed_filename, Journal, new_entry_path, slugify},
+    journal::{entry_filename, is_managed_filename, Journal, slugify},
     parser::{read_entry, render_entry, write_entry},
     period::Period,
 };
@@ -243,7 +243,9 @@ pub fn create_entry(
     body: String,
     fields: EntryFields,
 ) -> Result<PathBuf> {
-    let dest = journal.root.join(new_entry_path(name));
+    let id = CarettaId::now_unix();
+    let year = chrono::Local::now().year();
+    let dest = journal.root.join(year.to_string()).join(entry_filename(id, name));
     if dest.exists() {
         return Err(Error::EntryAlreadyExists(dest.display().to_string()));
     }
@@ -275,6 +277,7 @@ pub fn create_entry(
     let entry = Entry {
         path: dest.clone(),
         frontmatter: Frontmatter {
+            id,
             title: fm_title,
             slug: fields.slug,
             tags,
@@ -400,10 +403,7 @@ pub fn check_entry(path: &Path) -> Result<Vec<CheckIssue>> {
     }
 
     let entry = read_entry(path)?;
-    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
-    // Safety: `is_managed_filename` guarantees a valid 7-char CarettaId prefix.
-    let id: CarettaId = stem[..7].parse().unwrap();
-    let expected = entry_filename_from_frontmatter(id, &entry.frontmatter);
+    let expected = entry_filename_from_frontmatter(entry.frontmatter.id, &entry.frontmatter);
     let actual = path.file_name().and_then(|s| s.to_str()).unwrap_or_default();
 
     let mut issues = Vec::new();
@@ -428,10 +428,7 @@ pub fn fix_entry(path: &Path) -> Result<Option<PathBuf>> {
     }
 
     let entry = read_entry(path)?;
-    let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
-    let id: CarettaId = stem[..7].parse().unwrap();
-
-    let expected = entry_filename_from_frontmatter(id, &entry.frontmatter);
+    let expected = entry_filename_from_frontmatter(entry.frontmatter.id, &entry.frontmatter);
     let actual = path.file_name().and_then(|s| s.to_str()).unwrap_or_default();
 
     if actual == expected {

--- a/archelon-core/src/parser.rs
+++ b/archelon-core/src/parser.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use caretta_id::CarettaId;
+
 use crate::{
     entry::{Entry, Frontmatter},
     error::{Error, Result},
@@ -12,7 +14,7 @@ const FENCE: &str = "---";
 /// Frontmatter is optional. If the file starts with `---`, everything until
 /// the closing `---` is parsed as YAML. The rest is the body.
 pub fn parse_entry(path: &Path, source: &str) -> Result<Entry> {
-    let (frontmatter, body) = split_frontmatter(source)?;
+    let (frontmatter, body) = split_frontmatter(path, source)?;
     Ok(Entry {
         path: path.to_path_buf(),
         frontmatter,
@@ -26,15 +28,30 @@ pub fn read_entry(path: &Path) -> Result<Entry> {
     parse_entry(path, &source)
 }
 
-fn split_frontmatter(source: &str) -> Result<(Frontmatter, &str)> {
+fn id_from_path(path: &Path) -> Option<CarettaId> {
+    let stem = path.file_stem()?.to_str()?;
+    stem.get(..7)?.parse().ok()
+}
+
+fn split_frontmatter<'a>(path: &Path, source: &'a str) -> Result<(Frontmatter, &'a str)> {
     let Some(rest) = source.strip_prefix(FENCE) else {
-        // No frontmatter — treat whole file as body.
-        return Ok((Frontmatter::default(), source));
+        // No frontmatter block — derive ID from filename.
+        let id = id_from_path(path).ok_or_else(|| {
+            Error::InvalidEntry(
+                "no frontmatter and filename does not contain a valid CarettaId".into(),
+            )
+        })?;
+        return Ok((Frontmatter { id, title: None, slug: None, created_at: None, updated_at: None, tags: Vec::new(), task: None, event: None }, source));
     };
 
     // The opening `---` must be followed by a newline.
     let Some(rest) = rest.strip_prefix('\n') else {
-        return Ok((Frontmatter::default(), source));
+        let id = id_from_path(path).ok_or_else(|| {
+            Error::InvalidEntry(
+                "no frontmatter and filename does not contain a valid CarettaId".into(),
+            )
+        })?;
+        return Ok((Frontmatter { id, title: None, slug: None, created_at: None, updated_at: None, tags: Vec::new(), task: None, event: None }, source));
     };
 
     let Some(end) = rest.find(&format!("\n{FENCE}")) else {
@@ -82,14 +99,15 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    fn dummy_path() -> PathBuf {
-        PathBuf::from("test.md")
+    /// A valid archelon-managed path with CarettaId "0000000" (NIL).
+    fn managed_path() -> PathBuf {
+        PathBuf::from("0000000_test.md")
     }
 
     #[test]
     fn parses_entry_with_frontmatter() {
-        let src = "---\ntitle: Hello\ntags: [rust, cli]\n---\nsome body\n";
-        let entry = parse_entry(&dummy_path(), src).unwrap();
+        let src = "---\nid: '0000000'\ntitle: Hello\ntags: [rust, cli]\n---\nsome body\n";
+        let entry = parse_entry(&managed_path(), src).unwrap();
         assert_eq!(entry.frontmatter.title.as_deref(), Some("Hello"));
         assert_eq!(entry.frontmatter.tags, vec!["rust", "cli"]);
         assert_eq!(entry.body, "some body\n");
@@ -98,7 +116,7 @@ mod tests {
     #[test]
     fn parses_entry_without_frontmatter() {
         let src = "just a body\n";
-        let entry = parse_entry(&dummy_path(), src).unwrap();
+        let entry = parse_entry(&managed_path(), src).unwrap();
         assert!(entry.frontmatter.title.is_none());
         assert_eq!(entry.body, "just a body\n");
     }
@@ -106,14 +124,15 @@ mod tests {
     #[test]
     fn title_falls_back_to_file_stem() {
         let src = "body\n";
-        let entry = parse_entry(&PathBuf::from("my-note.md"), src).unwrap();
-        assert_eq!(entry.title(), "my-note");
+        let entry = parse_entry(&PathBuf::from("0000000_my-note.md"), src).unwrap();
+        assert_eq!(entry.title(), "0000000_my-note");
     }
 
     #[test]
     fn renders_entry_with_task() {
         use crate::entry::TaskMeta;
-        let mut entry = parse_entry(&dummy_path(), "body\n").unwrap();
+        let src = "---\nid: '0000000'\n---\nbody\n";
+        let mut entry = parse_entry(&managed_path(), src).unwrap();
         entry.frontmatter.title = Some("My Task".into());
         entry.frontmatter.task = Some(TaskMeta {
             status: Some("open".into()),

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -267,7 +267,7 @@ impl ArchelonServer {
                 .iter()
                 .map(|(entry, labels)| {
                     let mut v = serde_json::json!({
-                        "id": entry.id().map(|id| id.to_string()),
+                        "id": entry.id().to_string(),
                         "path": entry.path.display().to_string(),
                         "title": entry.title(),
                         "slug": entry.frontmatter.slug,


### PR DESCRIPTION
Store the CarettaId in the YAML frontmatter as a required field instead of deriving it solely from the filename. new_entry_path now returns the generated id alongside the path so create_entry can embed it; the parser falls back to the filename when no frontmatter block is present.