### PR TITLE
feat: auto-rename entry file on create and update

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -361,8 +361,11 @@ fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<(
         bail!("nothing to update — specify at least one field");
     }
     let _ = journal_dir; // reserved for future use
-    ops::update_entry(path, fields.into())?;
-    println!("updated: {}", path.display());
+    if let Some(new_path) = ops::update_entry(path, fields.into())? {
+        println!("updated and renamed: {}", new_path.display());
+    } else {
+        println!("updated: {}", path.display());
+    }
     Ok(())
 }
 

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -13,7 +13,7 @@ use crate::{
     entry::{Entry, EventMeta, Frontmatter, TaskMeta},
     entry_ref::EntryRef,
     error::{Error, Result},
-    journal::{entry_filename, is_managed_filename, Journal, slugify},
+    journal::{is_managed_filename, Journal, slugify},
     parser::{read_entry, render_entry, write_entry},
     period::Period,
 };
@@ -245,10 +245,6 @@ pub fn create_entry(
 ) -> Result<PathBuf> {
     let id = CarettaId::now_unix();
     let year = chrono::Local::now().year();
-    let dest = journal.root.join(year.to_string()).join(entry_filename(id, name));
-    if dest.exists() {
-        return Err(Error::EntryAlreadyExists(dest.display().to_string()));
-    }
 
     let fm_title = fields.title.or_else(|| Some(name.to_owned()));
     let tags = fields.tags.unwrap_or_default();
@@ -274,20 +270,25 @@ pub fn create_entry(
     };
 
     let now = chrono::Local::now().naive_local();
-    let entry = Entry {
-        path: dest.clone(),
-        frontmatter: Frontmatter {
-            id,
-            title: fm_title,
-            slug: fields.slug,
-            tags,
-            created_at: Some(now),
-            updated_at: Some(now),
-            task,
-            event,
-        },
-        body,
+    let frontmatter = Frontmatter {
+        id,
+        title: fm_title,
+        slug: fields.slug,
+        tags,
+        created_at: Some(now),
+        updated_at: Some(now),
+        task,
+        event,
     };
+
+    let dest = journal.root
+        .join(year.to_string())
+        .join(entry_filename_from_frontmatter(id, &frontmatter));
+    if dest.exists() {
+        return Err(Error::EntryAlreadyExists(dest.display().to_string()));
+    }
+
+    let entry = Entry { path: dest.clone(), frontmatter, body };
 
     std::fs::create_dir_all(dest.parent().unwrap())?;
     std::fs::write(&dest, render_entry(&entry))?;
@@ -299,7 +300,9 @@ pub fn create_entry(
 /// Update the frontmatter of the entry at `path` with non-`None` fields.
 ///
 /// `updated_at` is refreshed automatically by [`write_entry`].
-pub fn update_entry(path: &Path, fields: EntryFields) -> Result<()> {
+/// If the title or slug changed, the file is also renamed to match the new
+/// canonical filename.  Returns `Some(new_path)` when renamed, `None` otherwise.
+pub fn update_entry(path: &Path, fields: EntryFields) -> Result<Option<PathBuf>> {
     let mut entry = read_entry(path)?;
 
     if let Some(t) = fields.title {
@@ -343,7 +346,7 @@ pub fn update_entry(path: &Path, fields: EntryFields) -> Result<()> {
     }
 
     write_entry(&mut entry)?;
-    Ok(())
+    fix_entry(path)
 }
 
 // ── EntryRef resolution ───────────────────────────────────────────────────────

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -380,8 +380,12 @@ impl ArchelonServer {
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),
             )?;
-            ops::update_entry(&path, fields)?;
-            Ok(format!("updated: {}", path.display()))
+            let msg = if let Some(new_path) = ops::update_entry(&path, fields)? {
+                format!("updated and renamed: {}", new_path.display())
+            } else {
+                format!("updated: {}", path.display())
+            };
+            Ok(msg)
         })()
         .map_err(|e| e.to_string())
     }


### PR DESCRIPTION
- create_entry now derives the filename from frontmatter (slug/title) via entry_filename_from_frontmatter, so the canonical name is used from the start instead of relying on a separate fix step.
- update_entry now calls fix_entry after writing, automatically renaming the file when title or slug changes.  Return type changed from Result<()> to Result<Option<PathBuf>>.
- CLI and MCP callers updated to report "updated and renamed" when a rename occurs.