### PR TITLE
docs: update README to reflect current design and project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # archelon
 
-Markdown-based task and note manager that keeps your data alive as plain text — timeless like fossils.
+Markdown-based task and note manager for humans and AI agents — your data lives in plain text, timeless like fossils.
 
 ## Concept
 
 - **Markdown as source of truth** — all data lives in plain `.md` files you can read and edit with any tool
 - **SQLite as cache** — fast querying and indexing on top of the Markdown files (planned)
-- **Bullet-journal style** — notes and tasks coexist freely in one file, no forced separation
-- **Obsidian-compatible layout** — flat directory of `.md` files with YAML frontmatter and `[[wikilinks]]`
+- **Bullet-journal inspired** — tasks, events, and notes are equal peers, each living as its own entry; just as a bullet journal treats every bullet (task, event, or note) uniformly, archelon treats every entry the same way regardless of type
+- **Text-editor / IDE compatible** — plain `.md` files with YAML frontmatter; readable and editable in any editor without special tooling
 - **Human–AI collaborative editing** — designed to work alongside AI agents (Claude, etc.) that can read, create, and edit entries in the same journal via git or Syncthing sync
 
 ## Design decisions
@@ -28,17 +28,46 @@ The slug derived from the entry title keeps filenames readable even without open
 
 Each file is an **Entry** — the primary unit of data. An entry can contain free-form notes, task checkboxes (`- [ ]`), or both.
 
+A note entry:
+
 ```markdown
 ---
-title: My Note
-date: 2026-03-04
-tags: [work, project]
+id: '1a2b3c4'
+title: Meeting notes
+created_at: '2026-03-06T14:00:00'
+tags: [work]
 ---
 
-- [ ] Task A
-- [x] Task B (done)
+Discussion points from the team meeting.
+```
 
-Some free-form notes here.
+A task entry adds a `task` block:
+
+```markdown
+---
+id: '2b3c4d5'
+title: Fix login bug
+created_at: '2026-03-06T10:00:00'
+tags: [work, backend]
+task:
+  status: open
+  due: '2026-03-08T18:00:00'
+---
+
+Reproduction steps and notes here.
+```
+
+An event entry adds an `event` block:
+
+```markdown
+---
+id: '3c4d5e6'
+title: Team sync
+created_at: '2026-03-06T09:00:00'
+event:
+  start: '2026-03-07T15:00:00'
+  end: '2026-03-07T16:00:00'
+---
 ```
 
 ## CLI usage
@@ -54,13 +83,14 @@ Use `archelon init` to create one.
 ```
 archelon/
 ├── archelon-core/   # Data model, Markdown parser/serializer, (future) SQLite cache
-└── archelon-cli/    # CLI binary built with clap
+├── archelon-cli/    # CLI binary built with clap
+└── archelon-mcp/    # MCP server for AI agent integration
 ```
 
 ## Status
 
 Early development — CLI is functional for basic entry management.
-SQLite caching and `[[wikilink]]` support are planned.
+SQLite caching is planned.
 
 ## License
 


### PR DESCRIPTION
- Clarify bullet-journal inspiration: entries are peers like bullets, not bullet-points within entries
- Replace Obsidian-compatible with text-editor/IDE compatible
- Update frontmatter examples with current schema (id, created_at, task, event blocks)
- Add archelon-mcp to project structure
- Add AI agent angle to the one-liner description