### PR TITLE
feat: add tag/overdue filters and sort to entry list

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use archelon_core::{
     entry_ref::EntryRef,
     journal::Journal,
-    ops::{self, EntryFields as CoreEntryFields, EntryFilter, MatchLabel},
+    ops::{self, EntryFields as CoreEntryFields, EntryFilter, MatchLabel, SortField, SortOrder},
     period::{parse_datetime, parse_datetime_end, parse_period},
 };
 use chrono::NaiveDateTime;
@@ -53,6 +53,24 @@ pub enum EntryCommand {
         /// Comma-separated for multiple values, e.g. open,in_progress
         #[arg(long, value_name = "STATUS[,...]", value_delimiter = ',', num_args = 1..)]
         task_status: Option<Vec<String>>,
+
+        /// AND filter: include only entries that have ALL specified tags.
+        /// Comma-separated, e.g. work,urgent
+        #[arg(long, value_name = "TAG[,...]", value_delimiter = ',', num_args = 1..)]
+        tags: Option<Vec<String>>,
+
+        /// Include overdue tasks (due in the past, not yet closed). OR'd with period filters.
+        #[arg(long)]
+        overdue: bool,
+
+        /// Sort results by a field.
+        /// Values: id | title | task_status | created_at | updated_at | task_due | event_start | event_end
+        #[arg(long, value_name = "FIELD")]
+        sort_by: Option<String>,
+
+        /// Sort direction: asc (default) or desc
+        #[arg(long, value_name = "ORDER", default_value = "asc")]
+        sort_order: String,
 
         /// Output all matching entries as JSON (metadata + body) for AI/machine consumption
         #[arg(long)]
@@ -162,7 +180,7 @@ impl From<EntryFields> for CoreEntryFields {
 
 pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
     match cmd {
-        EntryCommand::List { path, period, task_due, event_start, event_end, created_at, updated_at, task_status, json } => {
+        EntryCommand::List { path, period, task_due, event_start, event_end, created_at, updated_at, task_status, tags, overdue, sort_by, sort_order, json } => {
             // Resolve week_start from journal config (needed for this_week parsing)
             let week_start = open_journal(journal_dir)
                 .and_then(|j| j.config().map_err(Into::into))
@@ -179,6 +197,12 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
                 created_at: created_at.as_deref().map(parse).transpose()?,
                 updated_at: updated_at.as_deref().map(parse).transpose()?,
                 task_status: task_status.unwrap_or_default(),
+                tags: tags.unwrap_or_default(),
+                overdue,
+                sort_by: sort_by.as_deref()
+                    .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
+                    .transpose()?,
+                sort_order: sort_order.parse::<SortOrder>().map_err(anyhow::Error::msg)?,
             };
 
             let entries = ops::list_entries(journal_dir, path.as_deref(), &filter)?;

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -4,7 +4,7 @@
 //! caller only needs to handle input-format concerns (CLI arg parsing, JSON
 //! deserialization, etc.) and output formatting.
 
-use std::path::{Path, PathBuf};
+use std::{cmp::Ordering, path::{Path, PathBuf}, str::FromStr};
 
 use caretta_id::CarettaId;
 use chrono::{Datelike as _, NaiveDateTime};
@@ -18,6 +18,61 @@ use crate::{
     period::Period,
 };
 
+// ── SortField / SortOrder ─────────────────────────────────────────────────────
+
+/// Which field to sort entries by in [`list_entries`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SortField {
+    #[default]
+    Id,
+    Title,
+    TaskStatus,
+    CreatedAt,
+    UpdatedAt,
+    TaskDue,
+    EventStart,
+    EventEnd,
+}
+
+impl FromStr for SortField {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "id"           => Ok(Self::Id),
+            "title"        => Ok(Self::Title),
+            "task_status"  => Ok(Self::TaskStatus),
+            "created_at"   => Ok(Self::CreatedAt),
+            "updated_at"   => Ok(Self::UpdatedAt),
+            "task_due"     => Ok(Self::TaskDue),
+            "event_start"  => Ok(Self::EventStart),
+            "event_end"    => Ok(Self::EventEnd),
+            other => Err(format!(
+                "unknown sort field `{other}`; expected one of: \
+                 id, title, task_status, created_at, updated_at, task_due, event_start, event_end"
+            )),
+        }
+    }
+}
+
+/// Sort direction for [`list_entries`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SortOrder {
+    #[default]
+    Asc,
+    Desc,
+}
+
+impl FromStr for SortOrder {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "asc"  => Ok(Self::Asc),
+            "desc" => Ok(Self::Desc),
+            other  => Err(format!("unknown sort order `{other}`; expected `asc` or `desc`")),
+        }
+    }
+}
+
 // ── EntryFilter ───────────────────────────────────────────────────────────────
 
 /// Filter criteria for [`list_entries`].
@@ -25,8 +80,7 @@ use crate::{
 /// Timestamp fields are ORed: an entry is included when *any* specified
 /// timestamp filter matches its corresponding field.
 ///
-/// `task_status` is ANDed on top: if non-empty, the entry must also have a
-/// task whose status appears in the list.
+/// `task_status` and `tags` are ANDed on top.
 #[derive(Debug, Default)]
 pub struct EntryFilter {
     /// Shortcut: apply the same period to all timestamp fields simultaneously.
@@ -38,6 +92,15 @@ pub struct EntryFilter {
     pub updated_at: Option<Period>,
     /// AND condition on task status (empty = no constraint).
     pub task_status: Vec<String>,
+    /// AND condition: entry must contain ALL of these tags (empty = no constraint).
+    pub tags: Vec<String>,
+    /// OR condition with timestamp filters: include tasks whose `due` is in the past
+    /// and `closed_at` is absent.
+    pub overdue: bool,
+    /// Field to sort results by (`None` = keep filesystem order).
+    pub sort_by: Option<SortField>,
+    /// Sort direction (default: ascending).
+    pub sort_order: SortOrder,
 }
 
 impl EntryFilter {
@@ -48,10 +111,11 @@ impl EntryFilter {
             || self.event_end.is_some()
             || self.created_at.is_some()
             || self.updated_at.is_some()
+            || self.overdue
     }
 
     pub fn has_any_filter(&self) -> bool {
-        self.has_timestamp_filter() || !self.task_status.is_empty()
+        self.has_timestamp_filter() || !self.task_status.is_empty() || !self.tags.is_empty()
     }
 
     /// Evaluate whether `entry` should be included.
@@ -94,6 +158,17 @@ impl EntryFilter {
             check!(self.created_at,  created_val,     MatchLabel::CreatedAt);
             check!(self.updated_at,  updated_val,     MatchLabel::UpdatedAt);
 
+            // overdue: task with due in the past and no closed_at
+            if self.overdue {
+                let is_overdue = entry.frontmatter.task.as_ref().is_some_and(|t| {
+                    t.due.is_some_and(|due| due < chrono::Local::now().naive_local())
+                        && t.closed_at.is_none()
+                });
+                if is_overdue {
+                    labels.push(MatchLabel::Overdue);
+                }
+            }
+
             labels.dedup();
             !labels.is_empty()
         } else {
@@ -109,7 +184,13 @@ impl EntryFilter {
             true
         };
 
-        (timestamp_ok && status_ok, labels)
+        let tags_ok = if !self.tags.is_empty() {
+            self.tags.iter().all(|tag| entry.frontmatter.tags.contains(tag))
+        } else {
+            true
+        };
+
+        (timestamp_ok && status_ok && tags_ok, labels)
     }
 }
 
@@ -123,6 +204,7 @@ pub enum MatchLabel {
     EventEnd,
     CreatedAt,
     UpdatedAt,
+    Overdue,
 }
 
 impl MatchLabel {
@@ -133,6 +215,7 @@ impl MatchLabel {
             MatchLabel::EventEnd   => "EVENT_END",
             MatchLabel::CreatedAt  => "CREATED",
             MatchLabel::UpdatedAt  => "UPDATED",
+            MatchLabel::Overdue    => "OVERDUE",
         }
     }
 }
@@ -174,7 +257,50 @@ pub fn list_entries(
         result.push((entry, labels));
     }
 
+    if let Some(field) = filter.sort_by {
+        result.sort_by(|(a, _), (b, _)| {
+            let ord = sort_cmp(a, b, field);
+            if filter.sort_order == SortOrder::Desc { ord.reverse() } else { ord }
+        });
+    }
+
     Ok(result)
+}
+
+fn sort_cmp(a: &Entry, b: &Entry, field: SortField) -> Ordering {
+    match field {
+        SortField::Id => a.id().cmp(&b.id()),
+        SortField::Title => a.title().cmp(b.title()),
+        SortField::TaskStatus => {
+            let sa = a.frontmatter.task.as_ref().and_then(|t| t.status.as_deref()).unwrap_or("");
+            let sb = b.frontmatter.task.as_ref().and_then(|t| t.status.as_deref()).unwrap_or("");
+            sa.cmp(sb)
+        }
+        SortField::CreatedAt  => cmp_opt(a.frontmatter.created_at, b.frontmatter.created_at),
+        SortField::UpdatedAt  => cmp_opt(a.frontmatter.updated_at, b.frontmatter.updated_at),
+        SortField::TaskDue    => cmp_opt(
+            a.frontmatter.task.as_ref().and_then(|t| t.due),
+            b.frontmatter.task.as_ref().and_then(|t| t.due),
+        ),
+        SortField::EventStart => cmp_opt(
+            a.frontmatter.event.as_ref().and_then(|e| e.start),
+            b.frontmatter.event.as_ref().and_then(|e| e.start),
+        ),
+        SortField::EventEnd   => cmp_opt(
+            a.frontmatter.event.as_ref().and_then(|e| e.end),
+            b.frontmatter.event.as_ref().and_then(|e| e.end),
+        ),
+    }
+}
+
+/// Compare two `Option<T>` values; `None` sorts after `Some(_)`.
+fn cmp_opt<T: Ord>(a: Option<T>, b: Option<T>) -> Ordering {
+    match (a, b) {
+        (Some(x), Some(y)) => x.cmp(&y),
+        (Some(_), None)    => Ordering::Less,
+        (None,    Some(_)) => Ordering::Greater,
+        (None,    None)    => Ordering::Equal,
+    }
 }
 
 /// Collect `.md` file paths for listing.

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use archelon_core::{
     entry_ref::EntryRef,
     journal::{Journal, WeekStart},
-    ops::{self, EntryFields, EntryFilter},
+    ops::{self, EntryFields, EntryFilter, SortField, SortOrder},
     parser::read_entry,
     period::{parse_datetime, parse_datetime_end, parse_period},
 };
@@ -90,6 +90,21 @@ struct EntryListParams {
     /// AND filter: include only entries whose task status matches one of these values.
     /// Provide as an array, e.g. ["open", "in_progress"]
     task_status: Option<Vec<String>>,
+
+    /// AND filter: include only entries that have ALL of these tags.
+    /// Provide as an array, e.g. ["work", "urgent"]
+    tags: Option<Vec<String>>,
+
+    /// OR filter with period: include tasks whose due date is in the past and closed_at is absent.
+    /// Can be combined with period; either condition is sufficient for inclusion.
+    overdue: Option<bool>,
+
+    /// Field to sort results by.
+    /// Accepted values: id | title | task_status | created_at | updated_at | task_due | event_start | event_end
+    sort_by: Option<String>,
+
+    /// Sort direction: "asc" (default) or "desc"
+    sort_order: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -242,9 +257,9 @@ impl ArchelonServer {
     }
 
     #[tool(description = "List journal entries as JSON. \
-        Timestamp filters (period, task_due, event_start, event_end, created_at, updated_at) are ORed: \
-        an entry matches if any specified timestamp field falls within the given period. \
-        task_status is ANDed on top: if provided, the entry must also have a matching task status.")]
+        Timestamp filters (period, task_due, event_start, event_end, created_at, updated_at, overdue) are ORed: \
+        an entry matches if any specified timestamp condition is satisfied. \
+        task_status and tags are ANDed on top.")]
     fn entry_list(&self, Parameters(p): Parameters<EntryListParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             let week_start = self.week_start();
@@ -258,6 +273,15 @@ impl ArchelonServer {
                 created_at: p.created_at.as_deref().map(parse).transpose()?,
                 updated_at: p.updated_at.as_deref().map(parse).transpose()?,
                 task_status: p.task_status.unwrap_or_default(),
+                tags: p.tags.unwrap_or_default(),
+                overdue: p.overdue.unwrap_or(false),
+                sort_by: p.sort_by.as_deref()
+                    .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
+                    .transpose()?,
+                sort_order: p.sort_order.as_deref()
+                    .map(|s| s.parse::<SortOrder>().map_err(anyhow::Error::msg))
+                    .transpose()?
+                    .unwrap_or_default(),
             };
 
             let has_filter = filter.has_any_filter();


### PR DESCRIPTION
- tags filter (AND): entries must contain all specified tags
- overdue filter (OR with period): tasks past due with no closed_at
- sort_by / sort_order: sort by id, title, task_status, or any timestamp field