### PR TITLE
refactor: unify title param and make frontmatter fields required

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -84,8 +84,9 @@ pub enum EntryCommand {
     /// Create a new entry.
     /// Without --body, opens $EDITOR (like `git commit` without -m).
     New {
-        /// Name of the entry — used as the title and to generate the filename slug
-        name: String,
+        /// Title of the entry — written into the frontmatter and used to generate the filename slug
+        #[arg(long, short)]
+        title: String,
 
         /// Inline body content — skips the editor (like git commit -m)
         #[arg(long, short)]
@@ -103,6 +104,10 @@ pub enum EntryCommand {
     Set {
         /// Path to the entry file, or an ID / ID prefix
         entry: String,
+
+        /// New title
+        #[arg(long, short)]
+        title: Option<String>,
 
         #[command(flatten)]
         fields: EntryFields,
@@ -130,10 +135,6 @@ pub enum EntryCommand {
 /// and passed to the core operation functions.
 #[derive(Args)]
 pub struct EntryFields {
-    /// Title written into the frontmatter
-    #[arg(long, short)]
-    pub title: Option<String>,
-
     /// Slug override in the frontmatter
     #[arg(long)]
     pub slug: Option<String>,
@@ -166,7 +167,6 @@ pub struct EntryFields {
 impl From<EntryFields> for CoreEntryFields {
     fn from(f: EntryFields) -> Self {
         Self {
-            title: f.title,
             slug: f.slug,
             tags: f.tags,
             task_due: f.task_due,
@@ -209,9 +209,9 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
             print_entries(&entries, filter.has_any_filter(), json)
         }
         EntryCommand::Show { entry } => show(&resolve_entry(journal_dir, &entry)?),
-        EntryCommand::New { name, body, fields } => new(journal_dir, &name, body, fields),
+        EntryCommand::New { title, body, fields } => new(journal_dir, title, body, fields),
         EntryCommand::Edit { entry } => edit(&resolve_entry(journal_dir, &entry)?),
-        EntryCommand::Set { entry, fields } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields),
+        EntryCommand::Set { entry, title, fields } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, title, fields),
         EntryCommand::Check { entry } => check(journal_dir, &entry),
         EntryCommand::Fix { entry } => fix(journal_dir, &entry),
         EntryCommand::Remove { entry } => remove(journal_dir, &entry),
@@ -302,12 +302,8 @@ fn show(path: &Path) -> Result<()> {
     let fm = &entry.frontmatter;
 
     println!("# {}", entry.title());
-    if let Some(ts) = fm.created_at {
-        println!("created:  {}", ts.format("%Y-%m-%dT%H:%M"));
-    }
-    if let Some(ts) = fm.updated_at {
-        println!("updated:  {}", ts.format("%Y-%m-%dT%H:%M"));
-    }
+    println!("created:  {}", fm.created_at.format("%Y-%m-%dT%H:%M"));
+    println!("updated:  {}", fm.updated_at.format("%Y-%m-%dT%H:%M"));
     if !fm.tags.is_empty() {
         println!("tags:     {}", fm.tags.join(", "));
     }
@@ -336,19 +332,18 @@ fn show(path: &Path) -> Result<()> {
 
 // ── new ───────────────────────────────────────────────────────────────────────
 
-fn new(journal_dir: Option<&Path>, name: &str, body: Option<String>, fields: EntryFields) -> Result<()> {
+fn new(journal_dir: Option<&Path>, title: String, body: Option<String>, fields: EntryFields) -> Result<()> {
     let journal = open_journal(journal_dir)?;
 
     let body = match body {
         Some(b) => b,
         None => {
-            let title = fields.title.as_deref().unwrap_or(name);
             let tags = fields.tags.as_deref().unwrap_or(&[]);
-            prompt_editor(Some(title), tags)?
+            prompt_editor(Some(&title), tags)?
         }
     };
 
-    let dest = ops::create_entry(&journal, name, body, fields.into())?;
+    let dest = ops::create_entry(&journal, &title, body, fields.into())?;
     println!("created: {}", dest.display());
     Ok(())
 }
@@ -372,8 +367,8 @@ fn edit(path: &Path) -> Result<()> {
 
 // ── set ───────────────────────────────────────────────────────────────────────
 
-fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<()> {
-    if fields.title.is_none()
+fn set(journal_dir: Option<&Path>, path: &Path, title: Option<String>, fields: EntryFields) -> Result<()> {
+    if title.is_none()
         && fields.slug.is_none()
         && fields.tags.is_none()
         && fields.task_due.is_none()
@@ -385,7 +380,7 @@ fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<(
         bail!("nothing to update — specify at least one field");
     }
     let _ = journal_dir; // reserved for future use
-    if let Some(new_path) = ops::update_entry(path, fields.into())? {
+    if let Some(new_path) = ops::update_entry(path, title, fields.into())? {
         println!("updated and renamed: {}", new_path.display());
     } else {
         println!("updated: {}", path.display());

--- a/archelon-core/src/entry.rs
+++ b/archelon-core/src/entry.rs
@@ -8,20 +8,20 @@ use std::path::PathBuf;
 pub struct Frontmatter {
     pub id: CarettaId,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+    #[serde(default)]
+    pub title: String,
 
     /// Optional slug override. If absent, the slug is derived from the filename.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
 
     /// Timestamp when the entry was first created. Set automatically by `new`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<NaiveDateTime>,
+    #[serde(default)]
+    pub created_at: NaiveDateTime,
 
     /// Timestamp of the last write. Updated automatically by `write_entry`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub updated_at: Option<NaiveDateTime>,
+    #[serde(default)]
+    pub updated_at: NaiveDateTime,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
@@ -91,10 +91,10 @@ impl Entry {
         self.frontmatter.id
     }
 
-    /// Returns the title: frontmatter title → file stem → "(untitled)".
+    /// Returns the title: frontmatter title (if non-empty) → file stem → "(untitled)".
     pub fn title(&self) -> &str {
-        if let Some(ref t) = self.frontmatter.title {
-            return t.as_str();
+        if !self.frontmatter.title.is_empty() {
+            return &self.frontmatter.title;
         }
         self.path
             .file_stem()

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -129,8 +129,8 @@ impl EntryFilter {
             let task_due_val = entry.frontmatter.task.as_ref().and_then(|t| t.due);
             let event_start_val = entry.frontmatter.event.as_ref().and_then(|e| e.start);
             let event_end_val = entry.frontmatter.event.as_ref().and_then(|e| e.end);
-            let created_val = entry.frontmatter.created_at;
-            let updated_val = entry.frontmatter.updated_at;
+            let created_val = Some(entry.frontmatter.created_at);
+            let updated_val = Some(entry.frontmatter.updated_at);
 
             macro_rules! check {
                 ($filter:expr, $val:expr, $label:expr) => {
@@ -276,8 +276,8 @@ fn sort_cmp(a: &Entry, b: &Entry, field: SortField) -> Ordering {
             let sb = b.frontmatter.task.as_ref().and_then(|t| t.status.as_deref()).unwrap_or("");
             sa.cmp(sb)
         }
-        SortField::CreatedAt  => cmp_opt(a.frontmatter.created_at, b.frontmatter.created_at),
-        SortField::UpdatedAt  => cmp_opt(a.frontmatter.updated_at, b.frontmatter.updated_at),
+        SortField::CreatedAt  => a.frontmatter.created_at.cmp(&b.frontmatter.created_at),
+        SortField::UpdatedAt  => a.frontmatter.updated_at.cmp(&b.frontmatter.updated_at),
         SortField::TaskDue    => cmp_opt(
             a.frontmatter.task.as_ref().and_then(|t| t.due),
             b.frontmatter.task.as_ref().and_then(|t| t.due),
@@ -342,11 +342,10 @@ pub fn collect_entries(journal_dir: Option<&Path>, path: Option<&Path>) -> Resul
 
 /// Parsed frontmatter fields used for creating or updating an entry.
 ///
-/// All fields are optional. Callers (CLI, MCP, …) parse their input format
-/// into this type before calling [`create_entry`] or [`update_entry`].
+/// All fields are optional. `title` is passed separately to [`create_entry`]
+/// (required) and [`update_entry`] (optional).
 #[derive(Debug, Default)]
 pub struct EntryFields {
-    pub title: Option<String>,
     pub slug: Option<String>,
     /// `None` = leave tags unchanged; `Some([])` = clear all tags.
     pub tags: Option<Vec<String>>,
@@ -359,20 +358,19 @@ pub struct EntryFields {
 
 // ── create ────────────────────────────────────────────────────────────────────
 
-/// Create a new entry in `journal` with the given `name`, `body`, and `fields`.
+/// Create a new entry in `journal` with the given `title`, `body`, and `fields`.
 ///
 /// Returns the path of the newly created file.
 /// Fails with [`Error::EntryAlreadyExists`] if the destination already exists.
 pub fn create_entry(
     journal: &Journal,
-    name: &str,
+    title: &str,
     body: String,
     fields: EntryFields,
 ) -> Result<PathBuf> {
     let id = CarettaId::now_unix();
     let year = chrono::Local::now().year();
 
-    let fm_title = fields.title.or_else(|| Some(name.to_owned()));
     let tags = fields.tags.unwrap_or_default();
 
     let task = if fields.task_due.is_some()
@@ -398,11 +396,11 @@ pub fn create_entry(
     let now = chrono::Local::now().naive_local();
     let frontmatter = Frontmatter {
         id,
-        title: fm_title,
+        title: title.to_owned(),
         slug: fields.slug,
         tags,
-        created_at: Some(now),
-        updated_at: Some(now),
+        created_at: now,
+        updated_at: now,
         task,
         event,
     };
@@ -428,11 +426,11 @@ pub fn create_entry(
 /// `updated_at` is refreshed automatically by [`write_entry`].
 /// If the title or slug changed, the file is also renamed to match the new
 /// canonical filename.  Returns `Some(new_path)` when renamed, `None` otherwise.
-pub fn update_entry(path: &Path, fields: EntryFields) -> Result<Option<PathBuf>> {
+pub fn update_entry(path: &Path, title: Option<String>, fields: EntryFields) -> Result<Option<PathBuf>> {
     let mut entry = read_entry(path)?;
 
-    if let Some(t) = fields.title {
-        entry.frontmatter.title = Some(t);
+    if let Some(t) = title {
+        entry.frontmatter.title = t;
     }
     if let Some(s) = fields.slug {
         entry.frontmatter.slug = Some(s);
@@ -582,7 +580,7 @@ pub fn remove_entry(path: &Path) -> Result<()> {
 /// or `slugify(title)` as a fallback.
 fn entry_filename_from_frontmatter(id: CarettaId, fm: &Frontmatter) -> String {
     let slug = fm.slug.clone().unwrap_or_else(|| {
-        fm.title.as_deref().map(slugify).unwrap_or_default()
+        if fm.title.is_empty() { String::new() } else { slugify(&fm.title) }
     });
     if slug.is_empty() {
         format!("{id}.md")

--- a/archelon-core/src/parser.rs
+++ b/archelon-core/src/parser.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use caretta_id::CarettaId;
+use chrono::NaiveDateTime;
 
 use crate::{
     entry::{Entry, Frontmatter},
@@ -33,25 +34,32 @@ fn id_from_path(path: &Path) -> Option<CarettaId> {
     stem.get(..7)?.parse().ok()
 }
 
+fn bare_frontmatter(path: &Path) -> Result<Frontmatter> {
+    let id = id_from_path(path).ok_or_else(|| {
+        Error::InvalidEntry(
+            "no frontmatter and filename does not contain a valid CarettaId".into(),
+        )
+    })?;
+    Ok(Frontmatter {
+        id,
+        title: String::new(),
+        slug: None,
+        created_at: NaiveDateTime::default(),
+        updated_at: NaiveDateTime::default(),
+        tags: Vec::new(),
+        task: None,
+        event: None,
+    })
+}
+
 fn split_frontmatter<'a>(path: &Path, source: &'a str) -> Result<(Frontmatter, &'a str)> {
     let Some(rest) = source.strip_prefix(FENCE) else {
-        // No frontmatter block — derive ID from filename.
-        let id = id_from_path(path).ok_or_else(|| {
-            Error::InvalidEntry(
-                "no frontmatter and filename does not contain a valid CarettaId".into(),
-            )
-        })?;
-        return Ok((Frontmatter { id, title: None, slug: None, created_at: None, updated_at: None, tags: Vec::new(), task: None, event: None }, source));
+        return Ok((bare_frontmatter(path)?, source));
     };
 
     // The opening `---` must be followed by a newline.
     let Some(rest) = rest.strip_prefix('\n') else {
-        let id = id_from_path(path).ok_or_else(|| {
-            Error::InvalidEntry(
-                "no frontmatter and filename does not contain a valid CarettaId".into(),
-            )
-        })?;
-        return Ok((Frontmatter { id, title: None, slug: None, created_at: None, updated_at: None, tags: Vec::new(), task: None, event: None }, source));
+        return Ok((bare_frontmatter(path)?, source));
     };
 
     let Some(end) = rest.find(&format!("\n{FENCE}")) else {
@@ -89,7 +97,7 @@ pub fn render_entry(entry: &Entry) -> String {
 
 /// Write an [`Entry`] back to its source file, updating `updated_at` first.
 pub fn write_entry(entry: &mut Entry) -> Result<()> {
-    entry.frontmatter.updated_at = Some(chrono::Local::now().naive_local());
+    entry.frontmatter.updated_at = chrono::Local::now().naive_local();
     std::fs::write(&entry.path, render_entry(entry))?;
     Ok(())
 }
@@ -108,7 +116,7 @@ mod tests {
     fn parses_entry_with_frontmatter() {
         let src = "---\nid: '0000000'\ntitle: Hello\ntags: [rust, cli]\n---\nsome body\n";
         let entry = parse_entry(&managed_path(), src).unwrap();
-        assert_eq!(entry.frontmatter.title.as_deref(), Some("Hello"));
+        assert_eq!(entry.frontmatter.title, "Hello");
         assert_eq!(entry.frontmatter.tags, vec!["rust", "cli"]);
         assert_eq!(entry.body, "some body\n");
     }
@@ -117,7 +125,7 @@ mod tests {
     fn parses_entry_without_frontmatter() {
         let src = "just a body\n";
         let entry = parse_entry(&managed_path(), src).unwrap();
-        assert!(entry.frontmatter.title.is_none());
+        assert!(entry.frontmatter.title.is_empty());
         assert_eq!(entry.body, "just a body\n");
     }
 
@@ -133,7 +141,7 @@ mod tests {
         use crate::entry::TaskMeta;
         let src = "---\nid: '0000000'\n---\nbody\n";
         let mut entry = parse_entry(&managed_path(), src).unwrap();
-        entry.frontmatter.title = Some("My Task".into());
+        entry.frontmatter.title = "My Task".into();
         entry.frontmatter.task = Some(TaskMeta {
             status: Some("open".into()),
             due: Some("2026-03-10T00:00:00".parse().unwrap()),

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -115,12 +115,10 @@ struct EntryShowParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct EntryNewParams {
-    /// Name of the entry — used as the title and to generate the filename slug
-    name: String,
+    /// Title of the entry — written into the frontmatter and used to generate the filename slug
+    title: String,
     /// Body content (Markdown)
     body: String,
-    /// Title written into the frontmatter (defaults to `name`)
-    title: Option<String>,
     /// Slug override in the frontmatter
     slug: Option<String>,
     /// Tags as comma-separated string (e.g. "work,project")
@@ -180,7 +178,6 @@ struct EntryRemoveParams {
 // ── helpers for parameter parsing ─────────────────────────────────────────────
 
 fn parse_entry_fields(
-    title: Option<String>,
     slug: Option<String>,
     tags: Option<String>,
     task_due: Option<&str>,
@@ -190,7 +187,6 @@ fn parse_entry_fields(
     event_end: Option<&str>,
 ) -> anyhow::Result<EntryFields> {
     Ok(EntryFields {
-        title,
         slug,
         tags: tags.as_deref().map(|s| {
             s.split(',')
@@ -324,12 +320,8 @@ impl ArchelonServer {
             let fm = &entry.frontmatter;
 
             let mut out = format!("# {}\n", entry.title());
-            if let Some(ts) = fm.created_at {
-                out.push_str(&format!("created:  {}\n", ts.format("%Y-%m-%dT%H:%M")));
-            }
-            if let Some(ts) = fm.updated_at {
-                out.push_str(&format!("updated:  {}\n", ts.format("%Y-%m-%dT%H:%M")));
-            }
+            out.push_str(&format!("created:  {}\n", fm.created_at.format("%Y-%m-%dT%H:%M")));
+            out.push_str(&format!("updated:  {}\n", fm.updated_at.format("%Y-%m-%dT%H:%M")));
             if !fm.tags.is_empty() {
                 out.push_str(&format!("tags:     {}\n", fm.tags.join(", ")));
             }
@@ -363,7 +355,6 @@ impl ArchelonServer {
         (|| -> anyhow::Result<String> {
             let journal = self.open_journal()?;
             let fields = parse_entry_fields(
-                p.title,
                 p.slug,
                 p.tags,
                 p.task_due.as_deref(),
@@ -372,7 +363,7 @@ impl ArchelonServer {
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),
             )?;
-            let dest = ops::create_entry(&journal, &p.name, p.body, fields)?;
+            let dest = ops::create_entry(&journal, &p.title, p.body, fields)?;
             Ok(format!("created: {}", dest.display()))
         })()
         .map_err(|e| e.to_string())
@@ -395,7 +386,6 @@ impl ArchelonServer {
 
             let path = self.resolve_entry(&p.entry)?;
             let fields = parse_entry_fields(
-                p.title,
                 p.slug,
                 p.tags,
                 p.task_due.as_deref(),
@@ -404,7 +394,7 @@ impl ArchelonServer {
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),
             )?;
-            let msg = if let Some(new_path) = ops::update_entry(&path, fields)? {
+            let msg = if let Some(new_path) = ops::update_entry(&path, p.title, fields)? {
                 format!("updated and renamed: {}", new_path.display())
             } else {
                 format!("updated: {}", path.display())


### PR DESCRIPTION
- Remove duplicate name/title params: EntryCommand::New and EntryNewParams now take a single required `title` field
- EntryCommand::Set and EntrySetParams expose title as a direct optional arg
- Remove title from EntryFields (shared field struct)
- Frontmatter.title, created_at, updated_at are now non-optional String/NaiveDateTime (serde(default) preserves backward compat with old files)