### PR TITLE
refactor(entry list): replace per-field PERIOD args with boolean field selectors

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use archelon_core::{
     entry_ref::EntryRef,
     journal::Journal,
-    ops::{self, EntryFields as CoreEntryFields, EntryFilter, MatchLabel, SortField, SortOrder},
+    ops::{self, EntryFields as CoreEntryFields, EntryFilter, FieldSelector, MatchLabel, SortField, SortOrder},
     period::{parse_datetime, parse_datetime_end, parse_period},
 };
 use chrono::NaiveDateTime;
@@ -14,36 +14,37 @@ use std::{
 
 #[derive(Subcommand)]
 pub enum EntryCommand {
-    /// List entries; optionally filter by per-field period conditions and/or task status
+    /// List entries; optionally filter by period, field selectors, task status, and tags
     List {
         /// Directory to search (defaults to journal root, then current directory)
         path: Option<PathBuf>,
 
-        /// Convenience filter applied to all timestamp fields simultaneously (OR across fields).
-        /// Equivalent to setting --task-due, --event-span, --created-at, --updated-at
-        /// to the same period.
+        /// Time range to filter against. Without field selectors (--task-due, --event-span,
+        /// --created-at, --updated-at) the period is applied to all timestamp fields (OR).
+        /// Add field selectors to restrict matching to specific fields.
         ///
         /// PERIOD formats: today | this_week | this_month | none |
         /// YYYY-MM-DD | YYYY-MM-DD,YYYY-MM-DD | YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM
         #[arg(long, value_name = "PERIOD")]
         period: Option<String>,
 
-        /// Filter by task due date (PERIOD format, see --period)
-        #[arg(long, value_name = "PERIOD")]
-        task_due: Option<String>,
+        /// Restrict --period to task due date.
+        /// Without --period: include entries that have a task_due set.
+        #[arg(long)]
+        task_due: bool,
 
-        /// Filter by event span: include entries whose event [start, end] overlaps the given period.
-        /// Use this to find in-progress events on a specific date or within a range.
-        #[arg(long, value_name = "PERIOD")]
-        event_span: Option<String>,
+        /// Restrict --period to event span (overlap semantics).
+        /// Without --period: include entries that have an event set.
+        #[arg(long)]
+        event_span: bool,
 
-        /// Filter by created_at timestamp (PERIOD format, see --period)
-        #[arg(long, value_name = "PERIOD")]
-        created_at: Option<String>,
+        /// Restrict --period to created_at timestamp.
+        #[arg(long)]
+        created_at: bool,
 
-        /// Filter by updated_at timestamp (PERIOD format, see --period)
-        #[arg(long, value_name = "PERIOD")]
-        updated_at: Option<String>,
+        /// Restrict --period to updated_at timestamp.
+        #[arg(long)]
+        updated_at: bool,
 
         /// Filter by task status (AND with timestamp filters).
         /// Comma-separated for multiple values, e.g. open,in_progress
@@ -190,10 +191,7 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
 
             let filter = EntryFilter {
                 period: period.as_deref().map(parse).transpose()?,
-                task_due: task_due.as_deref().map(parse).transpose()?,
-                event_span: event_span.as_deref().map(parse).transpose()?,
-                created_at: created_at.as_deref().map(parse).transpose()?,
-                updated_at: updated_at.as_deref().map(parse).transpose()?,
+                fields: FieldSelector { task_due, event_span, created_at, updated_at },
                 task_status: task_status.unwrap_or_default(),
                 tags: tags.unwrap_or_default(),
                 overdue,

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -73,23 +73,46 @@ impl FromStr for SortOrder {
     }
 }
 
+// ── FieldSelector ─────────────────────────────────────────────────────────────
+
+/// Selects which timestamp fields [`EntryFilter::period`] applies to.
+///
+/// When all fields are `false` (the default), `period` applies to all fields
+/// simultaneously (OR across all).  Setting one or more fields to `true`
+/// restricts the period check to only those fields.
+///
+/// Without a `period`, a `true` flag means "the field must be present (set)".
+#[derive(Debug, Default, Clone)]
+pub struct FieldSelector {
+    pub task_due: bool,
+    pub event_span: bool,
+    pub created_at: bool,
+    pub updated_at: bool,
+}
+
+impl FieldSelector {
+    /// Returns `true` when no field is explicitly selected (i.e. all are `false`).
+    pub fn is_empty(&self) -> bool {
+        !self.task_due && !self.event_span && !self.created_at && !self.updated_at
+    }
+}
+
 // ── EntryFilter ───────────────────────────────────────────────────────────────
 
 /// Filter criteria for [`list_entries`].
 ///
-/// Timestamp fields are ORed: an entry is included when *any* specified
-/// timestamp filter matches its corresponding field.
+/// `period` combined with `fields` forms the timestamp filter:
+/// - `period` set, `fields` empty → apply the period to all timestamp fields (OR).
+/// - `period` set, `fields` non-empty → apply the period to only the selected fields (OR).
+/// - `period` absent, `fields` non-empty → include entries where the selected fields exist.
 ///
 /// `task_status` and `tags` are ANDed on top.
 #[derive(Debug, Default)]
 pub struct EntryFilter {
-    /// Shortcut: apply the same period to all timestamp fields simultaneously.
+    /// Period to match against timestamp fields.
     pub period: Option<Period>,
-    pub task_due: Option<Period>,
-    /// Filter by event span overlap: matches when the event's [start, end] range overlaps this period.
-    pub event_span: Option<Period>,
-    pub created_at: Option<Period>,
-    pub updated_at: Option<Period>,
+    /// Which fields the period applies to (empty = all fields).
+    pub fields: FieldSelector,
     /// AND condition on task status (empty = no constraint).
     pub task_status: Vec<String>,
     /// AND condition: entry must contain ALL of these tags (empty = no constraint).
@@ -105,12 +128,7 @@ pub struct EntryFilter {
 
 impl EntryFilter {
     pub fn has_timestamp_filter(&self) -> bool {
-        self.period.is_some()
-            || self.task_due.is_some()
-            || self.event_span.is_some()
-            || self.created_at.is_some()
-            || self.updated_at.is_some()
-            || self.overdue
+        self.period.is_some() || !self.fields.is_empty() || self.overdue
     }
 
     pub fn has_any_filter(&self) -> bool {
@@ -125,40 +143,24 @@ impl EntryFilter {
         let mut labels = Vec::new();
 
         let timestamp_ok = if self.has_timestamp_filter() {
-            let task_due_val = entry.frontmatter.task.as_ref().and_then(|t| t.due);
+            let task_due_val    = entry.frontmatter.task.as_ref().and_then(|t| t.due);
             let event_start_val = entry.frontmatter.event.as_ref().map(|e| e.start);
-            let event_end_val = entry.frontmatter.event.as_ref().map(|e| e.end);
-            let created_val = Some(entry.frontmatter.created_at);
-            let updated_val = Some(entry.frontmatter.updated_at);
+            let event_end_val   = entry.frontmatter.event.as_ref().map(|e| e.end);
+            let created_val     = Some(entry.frontmatter.created_at);
+            let updated_val     = Some(entry.frontmatter.updated_at);
 
-            macro_rules! check {
-                ($filter:expr, $val:expr, $label:expr) => {
-                    if let Some(p) = &$filter {
-                        if p.matches($val) {
-                            labels.push($label);
-                        }
-                    }
-                };
-            }
-
-            // --period applies to all fields simultaneously
             if let Some(p) = &self.period {
-                if p.matches(task_due_val) { labels.push(MatchLabel::TaskDue); }
-                if p.overlaps_event(event_start_val, event_end_val) { labels.push(MatchLabel::EventSpan); }
-                if p.matches(created_val) { labels.push(MatchLabel::CreatedAt); }
-                if p.matches(updated_val) { labels.push(MatchLabel::UpdatedAt); }
-            }
-
-            // per-field filters (dedup handles overlap with --period)
-            check!(self.task_due,   task_due_val, MatchLabel::TaskDue);
-            check!(self.created_at, created_val,  MatchLabel::CreatedAt);
-            check!(self.updated_at, updated_val,  MatchLabel::UpdatedAt);
-
-            // event span filter: overlap test
-            if let Some(p) = &self.event_span {
-                if p.overlaps_event(event_start_val, event_end_val) {
-                    labels.push(MatchLabel::EventSpan);
-                }
+                // No field selectors → apply to all fields simultaneously
+                let all = self.fields.is_empty();
+                if (all || self.fields.task_due)   && p.matches(task_due_val)                        { labels.push(MatchLabel::TaskDue); }
+                if (all || self.fields.event_span) && p.overlaps_event(event_start_val, event_end_val) { labels.push(MatchLabel::EventSpan); }
+                if (all || self.fields.created_at) && p.matches(created_val)                         { labels.push(MatchLabel::CreatedAt); }
+                if (all || self.fields.updated_at) && p.matches(updated_val)                         { labels.push(MatchLabel::UpdatedAt); }
+            } else {
+                // No period: field flags → check that the field exists (is set)
+                if self.fields.task_due   && task_due_val.is_some()                                   { labels.push(MatchLabel::TaskDue); }
+                if self.fields.event_span && (event_start_val.is_some() || event_end_val.is_some())   { labels.push(MatchLabel::EventSpan); }
+                // created_at / updated_at are always set on every entry → no useful existence check
             }
 
             // overdue: task with due in the past and no closed_at

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use archelon_core::{
     entry_ref::EntryRef,
     journal::{Journal, WeekStart},
-    ops::{self, EntryFields, EntryFilter, SortField, SortOrder},
+    ops::{self, EntryFields, EntryFilter, FieldSelector, SortField, SortOrder},
     parser::read_entry,
     period::{parse_datetime, parse_datetime_end, parse_period},
 };
@@ -65,25 +65,26 @@ struct InitParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct EntryListParams {
-    /// Convenience filter applied to all timestamp fields simultaneously (OR across fields).
-    /// Equivalent to setting task_due, event_span, created_at, updated_at to the same period.
+    /// Period to match against timestamp fields.
+    /// When no field selectors are set, the period applies to all fields (OR).
     ///
     /// Accepted formats: today | this_week | this_month | none |
     /// YYYY-MM-DD | YYYY-MM-DD,YYYY-MM-DD | YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM
     period: Option<String>,
 
-    /// Filter by task due date (same PERIOD format as `period`)
-    task_due: Option<String>,
+    /// Restrict period matching to task due date.
+    /// Without period: include entries that have a task_due set.
+    task_due: Option<bool>,
 
-    /// Filter by event span overlap: matches entries whose event [start, end] range overlaps
-    /// the given period. Use this to find in-progress events on a specific date or within a range.
-    event_span: Option<String>,
+    /// Restrict period matching to event span (overlap semantics).
+    /// Without period: include entries that have an event set.
+    event_span: Option<bool>,
 
-    /// Filter by created_at timestamp (same PERIOD format as `period`)
-    created_at: Option<String>,
+    /// Restrict period matching to created_at timestamp.
+    created_at: Option<bool>,
 
-    /// Filter by updated_at timestamp (same PERIOD format as `period`)
-    updated_at: Option<String>,
+    /// Restrict period matching to updated_at timestamp.
+    updated_at: Option<bool>,
 
     /// AND filter: include only entries whose task status matches one of these values.
     /// Provide as an array, e.g. ["open", "in_progress"]
@@ -253,10 +254,12 @@ impl ArchelonServer {
     }
 
     #[tool(description = "List journal entries as JSON. \
-        Timestamp filters (period, task_due, event_span, created_at, updated_at, overdue) are ORed: \
-        an entry matches if any specified timestamp condition is satisfied. \
+        Use `period` to specify a time range. \
+        Use field selectors (task_due, event_span, created_at, updated_at) to restrict which fields \
+        the period applies to; omitting all selectors applies the period to all fields (OR). \
+        Without a period, field selectors filter entries where that field is present. \
         event_span uses interval-overlap semantics so in-progress events are included. \
-        task_status and tags are ANDed on top.")]
+        task_status, tags, and overdue are independent AND/OR filters.")]
     fn entry_list(&self, Parameters(p): Parameters<EntryListParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             let week_start = self.week_start();
@@ -264,10 +267,12 @@ impl ArchelonServer {
 
             let filter = EntryFilter {
                 period: p.period.as_deref().map(parse).transpose()?,
-                task_due: p.task_due.as_deref().map(parse).transpose()?,
-                event_span: p.event_span.as_deref().map(parse).transpose()?,
-                created_at: p.created_at.as_deref().map(parse).transpose()?,
-                updated_at: p.updated_at.as_deref().map(parse).transpose()?,
+                fields: FieldSelector {
+                    task_due:   p.task_due.unwrap_or(false),
+                    event_span: p.event_span.unwrap_or(false),
+                    created_at: p.created_at.unwrap_or(false),
+                    updated_at: p.updated_at.unwrap_or(false),
+                },
                 task_status: p.task_status.unwrap_or_default(),
                 tags: p.tags.unwrap_or_default(),
                 overdue: p.overdue.unwrap_or(false),


### PR DESCRIPTION
Closes #23

## Summary

- `--task-due`, `--event-span`, `--created-at`, `--updated-at` are now boolean flags (field selectors) instead of each accepting their own `PERIOD` value
- `--period` remains the sole argument for specifying a time range
- A new `FieldSelector` struct in `archelon-core` carries the selection

## Behaviour

| Command | Effect |
|---|---|
| `--period this_week` | Apply period to all fields (OR) — same as before |
| `--period this_week --task-due` | Only match task due date |
| `--period today --event-span` | Only match event span (overlap) |
| `--period this_week --task-due --event-span` | Match either field |
| `--task-due` *(no period)* | Entries that have a `task_due` set |
| `--event-span` *(no period)* | Entries that have an event set |

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` — all 15 unit tests pass
- [x] Manual smoke test: `archelon entry list --period this_week`
- [x] Manual smoke test: `archelon entry list --period this_week --task-due`
- [x] Manual smoke test: `archelon entry list --task-due` (no period)
- [x] Manual smoke test: `archelon entry list --period today --event-span`

🤖 Generated with [Claude Code](https://claude.com/claude-code)