### PR TITLE
fix(core): prevent newline accumulation on repeated entry fix calls

### DIFF
--- a/archelon-core/src/parser.rs
+++ b/archelon-core/src/parser.rs
@@ -70,7 +70,7 @@ fn split_frontmatter<'a>(path: &Path, source: &'a str) -> Result<(Frontmatter, &
 
     let yaml = &rest[..end];
     let body = &rest[end + 1 + FENCE.len()..]; // skip `\n---`
-    let body = body.strip_prefix('\n').unwrap_or(body);
+    let body = body.trim_start_matches('\n');
 
     let frontmatter: Frontmatter = serde_yaml::from_str(yaml)?;
     Ok((frontmatter, body))


### PR DESCRIPTION
## Summary

- Fixed a bug where each call to `entry fix` added an extra blank line between the frontmatter fence and the body
- `split_frontmatter` was only stripping one leading `\n` from the body, but `render_entry` always emits one, causing the count to grow by one on every round-trip
- Changed `strip_prefix('\n')` to `trim_start_matches('\n')` to normalise all leading blank lines on parse, giving a stable round-trip

## Test plan

- [x] `cargo test -p archelon-core` passes
- [x] Running `archelon entry fix` multiple times on an existing entry no longer accumulates blank lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)