### PR TITLE
feat(core): add task.started_at timestamp with auto-set and --task-started filter

### DIFF
--- a/archelon-cli/src/commands/entry.rs
+++ b/archelon-cli/src/commands/entry.rs
@@ -60,6 +60,12 @@ pub enum EntryCommand {
         #[arg(long)]
         overdue: bool,
 
+        /// Include tasks that have been started (started_at set) and not yet closed.
+        /// When combined with --period, only tasks started on or before the period end are included.
+        /// OR'd with period filters.
+        #[arg(long)]
+        task_started: bool,
+
         /// Sort results by a field.
         /// Values: id | title | task_status | created_at | updated_at | task_due | event_start | event_end
         #[arg(long, value_name = "FIELD")]
@@ -167,6 +173,10 @@ pub struct EntryFields {
     #[arg(long)]
     pub task_status: Option<String>,
 
+    /// Task start date/time; set automatically when status → in_progress
+    #[arg(long, value_name = "DATETIME", value_parser = parse_datetime)]
+    pub task_started_at: Option<NaiveDateTime>,
+
     /// Task close date/time; set automatically when status → done/cancelled/archived
     #[arg(long, value_name = "DATETIME", value_parser = parse_datetime)]
     pub task_closed_at: Option<NaiveDateTime>,
@@ -187,6 +197,7 @@ impl From<EntryFields> for CoreEntryFields {
             tags: f.tags,
             task_due: f.task_due,
             task_status: f.task_status,
+            task_started_at: f.task_started_at,
             task_closed_at: f.task_closed_at,
             event_start: f.event_start,
             event_end: f.event_end,
@@ -196,7 +207,7 @@ impl From<EntryFields> for CoreEntryFields {
 
 pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
     match cmd {
-        EntryCommand::List { path, period, task_due, event_span, created_at, updated_at, task_status, tags, overdue, sort_by, sort_order, json } => {
+        EntryCommand::List { path, period, task_due, event_span, created_at, updated_at, task_status, tags, overdue, task_started, sort_by, sort_order, json } => {
             // Resolve week_start from journal config (needed for this_week parsing)
             let week_start = open_journal(journal_dir)
                 .and_then(|j| j.config().map_err(Into::into))
@@ -211,6 +222,7 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
                 task_status: task_status.unwrap_or_default(),
                 tags: tags.unwrap_or_default(),
                 overdue,
+                task_started,
                 sort_by: sort_by.as_deref()
                     .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
                     .transpose()?,
@@ -334,6 +346,9 @@ fn show(path: &Path) -> Result<()> {
             Some(d) => println!("task:     {status} (due {})", d.format("%Y-%m-%d")),
             None => println!("task:     {status}"),
         }
+        if let Some(sa) = task.started_at {
+            println!("started:  {}", sa.format("%Y-%m-%dT%H:%M"));
+        }
         if let Some(ca) = task.closed_at {
             println!("closed:   {}", ca.format("%Y-%m-%dT%H:%M"));
         }
@@ -407,6 +422,7 @@ fn set(journal_dir: Option<&Path>, path: &Path, title: Option<String>, fields: E
         && fields.tags.is_none()
         && fields.task_due.is_none()
         && fields.task_status.is_none()
+        && fields.task_started_at.is_none()
         && fields.task_closed_at.is_none()
         && fields.event_start.is_none()
         && fields.event_end.is_none()

--- a/archelon-core/src/entry.rs
+++ b/archelon-core/src/entry.rs
@@ -49,6 +49,11 @@ pub struct TaskMeta {
     #[serde(default = "default_task_status")]
     pub status: String,
 
+    /// Timestamp when the task was started (status → in_progress).
+    /// Set automatically by `entry set`; can be overridden manually.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "naive_datetime_serde::opt")]
+    pub started_at: Option<NaiveDateTime>,
+
     /// Timestamp when the task was closed (status → done/cancelled/archived).
     /// Set automatically by `entry set`; can be overridden manually.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "naive_datetime_serde::opt")]

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -120,6 +120,9 @@ pub struct EntryFilter {
     /// OR condition with timestamp filters: include tasks whose `due` is in the past
     /// and `closed_at` is absent.
     pub overdue: bool,
+    /// OR condition with timestamp filters: include tasks that have `started_at` set,
+    /// `closed_at` absent, and (when a period is active) `started_at` ≤ period end.
+    pub task_started: bool,
     /// Field to sort results by (`None` = keep filesystem order).
     pub sort_by: Option<SortField>,
     /// Sort direction (default: ascending).
@@ -128,7 +131,7 @@ pub struct EntryFilter {
 
 impl EntryFilter {
     pub fn has_timestamp_filter(&self) -> bool {
-        self.period.is_some() || !self.fields.is_empty() || self.overdue
+        self.period.is_some() || !self.fields.is_empty() || self.overdue || self.task_started
     }
 
     pub fn has_any_filter(&self) -> bool {
@@ -174,6 +177,22 @@ impl EntryFilter {
                 }
             }
 
+            // task_started: task with started_at set, no closed_at, and started_at ≤ period end
+            if self.task_started {
+                let period_end = match &self.period {
+                    Some(Period::Range(_, end)) => Some(*end),
+                    _ => None,
+                };
+                let is_started = entry.frontmatter.task.as_ref().is_some_and(|t| {
+                    t.started_at.is_some()
+                        && t.closed_at.is_none()
+                        && period_end.map_or(true, |end| t.started_at.unwrap() <= end)
+                });
+                if is_started {
+                    labels.push(MatchLabel::TaskStarted);
+                }
+            }
+
             labels.dedup();
             !labels.is_empty()
         } else {
@@ -205,6 +224,7 @@ impl EntryFilter {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MatchLabel {
     TaskDue,
+    TaskStarted,
     /// The filter period overlaps the event's [start, end] span.
     EventSpan,
     CreatedAt,
@@ -215,11 +235,12 @@ pub enum MatchLabel {
 impl MatchLabel {
     pub fn as_str(self) -> &'static str {
         match self {
-            MatchLabel::TaskDue   => "TASK_DUE",
-            MatchLabel::EventSpan => "EVENT_SPAN",
-            MatchLabel::CreatedAt => "CREATED",
-            MatchLabel::UpdatedAt => "UPDATED",
-            MatchLabel::Overdue   => "OVERDUE",
+            MatchLabel::TaskDue     => "TASK_DUE",
+            MatchLabel::TaskStarted => "TASK_STARTED",
+            MatchLabel::EventSpan   => "EVENT_SPAN",
+            MatchLabel::CreatedAt   => "CREATED",
+            MatchLabel::UpdatedAt   => "UPDATED",
+            MatchLabel::Overdue     => "OVERDUE",
         }
     }
 }
@@ -355,6 +376,7 @@ pub struct EntryFields {
     pub tags: Option<Vec<String>>,
     pub task_due: Option<NaiveDateTime>,
     pub task_status: Option<String>,
+    pub task_started_at: Option<NaiveDateTime>,
     pub task_closed_at: Option<NaiveDateTime>,
     pub event_start: Option<NaiveDateTime>,
     pub event_end: Option<NaiveDateTime>,
@@ -379,14 +401,19 @@ pub fn create_entry(
 
     let task = if fields.task_due.is_some()
         || fields.task_status.is_some()
+        || fields.task_started_at.is_some()
         || fields.task_closed_at.is_some()
     {
-        let inactive =
-            matches!(fields.task_status.as_deref(), Some("done" | "cancelled" | "archived"));
+        let status = fields.task_status.unwrap_or_else(|| "open".to_owned());
+        let inactive = matches!(status.as_str(), "done" | "cancelled" | "archived");
+        let in_progress = status == "in_progress";
+        let started_at = fields
+            .task_started_at
+            .or_else(|| in_progress.then(|| chrono::Local::now().naive_local()));
         let closed_at = fields
             .task_closed_at
             .or_else(|| inactive.then(|| chrono::Local::now().naive_local()));
-        Some(TaskMeta { due: fields.task_due, status: fields.task_status.unwrap_or_else(|| "open".to_owned()), closed_at })
+        Some(TaskMeta { due: fields.task_due, status, started_at, closed_at })
     } else {
         None
     };
@@ -450,22 +477,31 @@ pub fn update_entry(path: &Path, title: Option<String>, body: Option<String>, fi
 
     if fields.task_due.is_some()
         || fields.task_status.is_some()
+        || fields.task_started_at.is_some()
         || fields.task_closed_at.is_some()
     {
         let task = entry.frontmatter.task.get_or_insert_with(|| TaskMeta {
             status: "open".to_owned(),
             due: None,
+            started_at: None,
             closed_at: None,
         });
         if let Some(d) = fields.task_due {
             task.due = Some(d);
         }
         if let Some(s) = fields.task_status {
+            let in_progress = s == "in_progress";
             let inactive = matches!(s.as_str(), "done" | "cancelled" | "archived");
             task.status = s;
+            if in_progress && task.started_at.is_none() && fields.task_started_at.is_none() {
+                task.started_at = Some(chrono::Local::now().naive_local());
+            }
             if inactive && task.closed_at.is_none() && fields.task_closed_at.is_none() {
                 task.closed_at = Some(chrono::Local::now().naive_local());
             }
+        }
+        if let Some(sa) = fields.task_started_at {
+            task.started_at = Some(sa);
         }
         if let Some(ca) = fields.task_closed_at {
             task.closed_at = Some(ca);
@@ -597,6 +633,15 @@ pub fn check_entry(path: &Path) -> Result<Vec<CheckIssue>> {
 
 // ── fix ───────────────────────────────────────────────────────────────────────
 
+/// If the entry has a task with `in_progress` status and no `started_at`, set it to now.
+fn sync_started_at(entry: &mut Entry) {
+    if let Some(task) = &mut entry.frontmatter.task {
+        if task.status == "in_progress" && task.started_at.is_none() {
+            task.started_at = Some(chrono::Local::now().naive_local());
+        }
+    }
+}
+
 /// If the entry has a task with a closed status and no `closed_at`, set it to now.
 fn sync_closed_at(entry: &mut Entry) {
     if let Some(task) = &mut entry.frontmatter.task {
@@ -615,6 +660,7 @@ fn sync_closed_at(entry: &mut Entry) {
 ///
 /// Returns `Some(new_path)` if the file was renamed, `None` otherwise.
 fn fix_entry_mut(entry: &mut Entry, touch: bool) -> Result<Option<PathBuf>> {
+    sync_started_at(entry);
     sync_closed_at(entry);
     if touch {
         entry.frontmatter.updated_at = chrono::Local::now().naive_local();

--- a/archelon-core/src/parser.rs
+++ b/archelon-core/src/parser.rs
@@ -136,6 +136,7 @@ mod tests {
         entry.frontmatter.task = Some(TaskMeta {
             status: "open".into(),
             due: Some("2026-03-10T00:00:00".parse().unwrap()),
+            started_at: None,
             closed_at: None,
         });
         let rendered = render_entry(&entry);

--- a/archelon-mcp/src/main.rs
+++ b/archelon-mcp/src/main.rs
@@ -99,6 +99,10 @@ struct EntryListParams {
     /// Can be combined with period; either condition is sufficient for inclusion.
     overdue: Option<bool>,
 
+    /// OR filter with period: include tasks that have started_at set, closed_at absent,
+    /// and (when period is given) started_at ≤ period end.
+    task_started: Option<bool>,
+
     /// Field to sort results by.
     /// Accepted values: id | title | task_status | created_at | updated_at | task_due | event_start | event_end
     sort_by: Option<String>,
@@ -127,6 +131,8 @@ struct EntryNewParams {
     task_due: Option<String>,
     /// Task status (open | in_progress | done | cancelled | archived)
     task_status: Option<String>,
+    /// Task start date/time; set automatically when status → in_progress
+    task_started_at: Option<String>,
     /// Task close date/time
     task_closed_at: Option<String>,
     /// Event start date/time (YYYY-MM-DD or YYYY-MM-DDTHH:MM)
@@ -151,6 +157,8 @@ struct EntrySetParams {
     task_due: Option<String>,
     /// Task status (open | in_progress | done | cancelled | archived)
     task_status: Option<String>,
+    /// Task start date/time; set automatically when status → in_progress
+    task_started_at: Option<String>,
     /// Task close date/time
     task_closed_at: Option<String>,
     /// Event start date/time (YYYY-MM-DD or YYYY-MM-DDTHH:MM)
@@ -187,6 +195,7 @@ fn parse_entry_fields(
     tags: Option<String>,
     task_due: Option<&str>,
     task_status: Option<String>,
+    task_started_at: Option<&str>,
     task_closed_at: Option<&str>,
     event_start: Option<&str>,
     event_end: Option<&str>,
@@ -203,6 +212,9 @@ fn parse_entry_fields(
             .map(|s| parse_datetime_end(s).map_err(anyhow::Error::msg))
             .transpose()?,
         task_status,
+        task_started_at: task_started_at
+            .map(|s| parse_datetime(s).map_err(anyhow::Error::msg))
+            .transpose()?,
         task_closed_at: task_closed_at
             .map(|s| parse_datetime(s).map_err(anyhow::Error::msg))
             .transpose()?,
@@ -280,6 +292,7 @@ impl ArchelonServer {
                 task_status: p.task_status.unwrap_or_default(),
                 tags: p.tags.unwrap_or_default(),
                 overdue: p.overdue.unwrap_or(false),
+                task_started: p.task_started.unwrap_or(false),
                 sort_by: p.sort_by.as_deref()
                     .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
                     .transpose()?,
@@ -363,6 +376,7 @@ impl ArchelonServer {
                 p.tags,
                 p.task_due.as_deref(),
                 p.task_status,
+                p.task_started_at.as_deref(),
                 p.task_closed_at.as_deref(),
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),
@@ -382,6 +396,7 @@ impl ArchelonServer {
                 && p.tags.is_none()
                 && p.task_due.is_none()
                 && p.task_status.is_none()
+                && p.task_started_at.is_none()
                 && p.task_closed_at.is_none()
                 && p.event_start.is_none()
                 && p.event_end.is_none()
@@ -395,6 +410,7 @@ impl ArchelonServer {
                 p.tags,
                 p.task_due.as_deref(),
                 p.task_status,
+                p.task_started_at.as_deref(),
                 p.task_closed_at.as_deref(),
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),


### PR DESCRIPTION
## Summary

- Add `started_at: Option<NaiveDateTime>` to `TaskMeta` frontmatter, serialized as `task.started_at` in YAML (same format as `task.closed_at`)
- Auto-set `started_at` when task status transitions to `in_progress` (mirrors the existing `closed_at` auto-set for `done`/`cancelled`/`archived`); also synced by `entry fix`
- Add `--task-started` filter flag to `entry list`: includes tasks where `started_at` is set, `closed_at` is absent, and (when `--period` is given) `started_at ≤ period end` — i.e. tasks that were actively in progress during the period
- Add `--task-started-at DATETIME` option to `entry new` / `entry set` for manual timestamp override
- Expose all new fields and the `task_started` filter in the MCP server

## Usage examples

```bash
# List all in-progress tasks (started, not yet closed)
archelon entry list --task-started

# List tasks that were active as of today
archelon entry list --period today --task-started

# Transition a task to in_progress (started_at is set automatically)
archelon entry set <id> --task-status in_progress

# Override started_at manually
archelon entry set <id> --task-started-at 2026-03-01T09:00
```

## Test plan

- [x] `entry set --task-status in_progress` sets `started_at` automatically
- [x] `entry set --task-status in_progress` does not overwrite an existing `started_at`
- [x] `entry set --task-started-at` sets the timestamp explicitly
- [x] `entry fix` / `entry edit` syncs `started_at` for existing `in_progress` entries missing the field
- [x] `entry list --task-started` returns only tasks with `started_at` set and `closed_at` absent
- [x] `entry list --period today --task-started` respects the period end as an upper bound on `started_at`
- [x] `entry show` displays `started_at` when present
- [x] Existing entries without `started_at` parse correctly (field is optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)