### PR TITLE
feat(core): preserve unknown frontmatter fields across round-trips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ version = "0.2.1"
 dependencies = [
  "caretta-id",
  "chrono",
+ "indexmap",
  "serde",
  "serde_yaml",
  "thiserror",

--- a/archelon-core/Cargo.toml
+++ b/archelon-core/Cargo.toml
@@ -12,4 +12,5 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 toml = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
+indexmap = { version = "2", features = ["serde"] }
 thiserror = "2"

--- a/archelon-core/src/entry.rs
+++ b/archelon-core/src/entry.rs
@@ -1,5 +1,6 @@
 use caretta_id::CarettaId;
 use chrono::NaiveDateTime;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -33,6 +34,10 @@ pub struct Frontmatter {
     /// Event metadata. Present only when this entry represents a calendar event.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event: Option<EventMeta>,
+
+    /// Unknown frontmatter fields preserved for round-trip compatibility.
+    #[serde(flatten)]
+    pub extra: IndexMap<String, serde_yaml::Value>,
 }
 
 /// Task-specific metadata.
@@ -58,6 +63,10 @@ pub struct TaskMeta {
     /// Set automatically by `entry set`; can be overridden manually.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "naive_datetime_serde::opt")]
     pub closed_at: Option<NaiveDateTime>,
+
+    /// Unknown task fields preserved for round-trip compatibility.
+    #[serde(flatten)]
+    pub extra: IndexMap<String, serde_yaml::Value>,
 }
 
 fn default_task_status() -> String {
@@ -71,6 +80,10 @@ pub struct EventMeta {
     pub start: NaiveDateTime,
     #[serde(with = "naive_datetime_serde::eod")]
     pub end: NaiveDateTime,
+
+    /// Unknown event fields preserved for round-trip compatibility.
+    #[serde(flatten)]
+    pub extra: IndexMap<String, serde_yaml::Value>,
 }
 
 /// A single entry — one Markdown file in the journal.

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -6,6 +6,8 @@
 
 use std::{cmp::Ordering, path::{Path, PathBuf}, str::FromStr};
 
+use indexmap::IndexMap;
+
 use caretta_id::CarettaId;
 use chrono::{Datelike as _, NaiveDateTime};
 
@@ -413,7 +415,7 @@ pub fn create_entry(
         let closed_at = fields
             .task_closed_at
             .or_else(|| inactive.then(|| chrono::Local::now().naive_local()));
-        Some(TaskMeta { due: fields.task_due, status, started_at, closed_at })
+        Some(TaskMeta { due: fields.task_due, status, started_at, closed_at, extra: IndexMap::new() })
     } else {
         None
     };
@@ -421,7 +423,7 @@ pub fn create_entry(
     let event = if fields.event_start.is_some() || fields.event_end.is_some() {
         let start = fields.event_start.or(fields.event_end).unwrap();
         let end = fields.event_end.or(fields.event_start).unwrap();
-        Some(EventMeta { start, end })
+        Some(EventMeta { start, end, extra: IndexMap::new() })
     } else {
         None
     };
@@ -436,6 +438,7 @@ pub fn create_entry(
         updated_at: now,
         task,
         event,
+        extra: IndexMap::new(),
     };
 
     let dest = journal.root
@@ -485,6 +488,7 @@ pub fn update_entry(path: &Path, title: Option<String>, body: Option<String>, fi
             due: None,
             started_at: None,
             closed_at: None,
+            extra: IndexMap::new(),
         });
         if let Some(d) = fields.task_due {
             task.due = Some(d);
@@ -512,7 +516,7 @@ pub fn update_entry(path: &Path, title: Option<String>, body: Option<String>, fi
         let event = entry.frontmatter.event.get_or_insert_with(|| {
             let start = fields.event_start.or(fields.event_end).unwrap();
             let end = fields.event_end.or(fields.event_start).unwrap();
-            EventMeta { start, end }
+            EventMeta { start, end, extra: IndexMap::new() }
         });
         if let Some(s) = fields.event_start {
             event.start = s;

--- a/archelon-core/src/parser.rs
+++ b/archelon-core/src/parser.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use caretta_id::CarettaId;
 use chrono::NaiveDateTime;
+use indexmap::IndexMap;
 
 use crate::{
     entry::{Entry, Frontmatter},
@@ -49,6 +50,7 @@ fn bare_frontmatter(path: &Path) -> Result<Frontmatter> {
         tags: Vec::new(),
         task: None,
         event: None,
+        extra: IndexMap::new(),
     })
 }
 
@@ -103,6 +105,7 @@ pub fn write_entry(entry: &mut Entry) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use indexmap::IndexMap;
     use std::path::PathBuf;
 
     /// A valid archelon-managed path with CarettaId "0000000" (NIL).
@@ -138,6 +141,7 @@ mod tests {
             due: Some("2026-03-10T00:00:00".parse().unwrap()),
             started_at: None,
             closed_at: None,
+            extra: IndexMap::new(),
         });
         let rendered = render_entry(&entry);
         assert!(rendered.contains("title: My Task"));


### PR DESCRIPTION
## Summary

- Add `extra: IndexMap<String, serde_yaml::Value>` with `#[serde(flatten)]` to `Frontmatter`, `TaskMeta`, and `EventMeta`
- Unknown YAML keys are now captured on deserialization and re-emitted verbatim on serialization
- Prevents data loss when an older version of archelon writes back an entry that was enriched by a newer version with additional frontmatter fields

## Motivation

When multiple versions of archelon (or other compatible tools) share the same journal, newer versions may write frontmatter fields that older versions do not know about. Previously those unknown fields were silently dropped on the next `fix`/`write` pass by the older version. This change makes all versions forward-compatible with unknown fields by preserving them in a catch-all map.

## Changes

| File | Change |
|------|--------|
| `archelon-core/Cargo.toml` | Add `indexmap = { version = "2", features = ["serde"] }` |
| `archelon-core/src/entry.rs` | Add `extra` field to `Frontmatter`, `TaskMeta`, `EventMeta` |
| `archelon-core/src/ops.rs` | Initialize `extra: IndexMap::new()` in all struct literals |
| `archelon-core/src/parser.rs` | Initialize `extra: IndexMap::new()` in `bare_frontmatter` and tests |

## Test plan

- [x] All existing unit tests pass (`cargo test -p archelon-core`)
- [x] Manually create an entry with an unknown field (e.g. `foo: bar`) in the frontmatter, run `archelon entry fix`, and verify the field is still present in the output file

🤖 Generated with [Claude Code](https://claude.com/claude-code)