### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-03-09
+
+### Added
+
+- `task.started_at` timestamp field: auto-set when task status transitions to `in_progress`; supports manual override via `--task-started-at DATETIME` in `entry new` / `entry set`
+- `--task-started` filter for `entry list` (CLI and MCP): matches in-progress tasks (with optional `--period` overlap check)
+- Preserve unknown frontmatter fields across round-trips — unknown YAML keys in `Frontmatter`, `TaskMeta`, and `EventMeta` are now retained on read/write, preventing data loss when entries were created by a newer version of archelon
+
 ## [0.2.1] - 2026-03-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "archelon-cli"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "archelon-core",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "archelon-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "caretta-id",
  "chrono",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "archelon-mcp"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "archelon-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.2.1"
+version = "0.3.0"
 description = "Markdown-based task and note manager that keeps your data alive as plain text - timeless like fossils"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/archelon"

--- a/archelon-cli/Cargo.toml
+++ b/archelon-cli/Cargo.toml
@@ -16,7 +16,7 @@ pkg-fmt = "bin"
 bin-dir = "{ bin }{ binary-ext }"
 
 [dependencies]
-archelon-core = { path = "../archelon-core", version = "0.2.1" }
+archelon-core = { path = "../archelon-core", version = "0.3.0" }
 clap = { version = "4", features = ["derive", "env"] }
 anyhow = "1"
 chrono = { version = "0.4" }

--- a/archelon-mcp/Cargo.toml
+++ b/archelon-mcp/Cargo.toml
@@ -12,7 +12,7 @@ pkg-fmt = "bin"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-archelon-core = { path = "../archelon-core", version = "0.2.1" }
+archelon-core = { path = "../archelon-core", version = "0.3.0" }
 rmcp = { version = "1.1", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/archelon-vscode/CHANGELOG.md
+++ b/archelon-vscode/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the "archelon-vscode" extension will be documented in thi
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.3.0] - 2026-03-09
+
+### Added
+
+- Bundled CLI binary updated to v0.3.0: `task.started_at` timestamp with `--task-started` filter, and preservation of unknown frontmatter fields
+
 ## [0.2.1] - 2026-03-08
 
 ### Fixed

--- a/archelon-vscode/package.json
+++ b/archelon-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Archelon",
   "publisher": "fluo10",
   "description": "VS Code extension for the Archelon journal",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/fluo10/archelon"


### PR DESCRIPTION
## Summary

- Bump workspace version to `0.3.0` (Cargo.toml, archelon-cli, archelon-mcp, archelon-vscode)
- Update CHANGELOG.md and archelon-vscode/CHANGELOG.md with v0.3.0 entries

## Changes in this release

- `task.started_at` timestamp field — auto-set on `in_progress` transition; manual override via `--task-started-at`
- `--task-started` filter for `entry list` (CLI and MCP) — matches in-progress tasks with optional `--period` overlap
- Preserve unknown frontmatter fields across round-trips (forward-compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)