### PR TITLE
chore: add categories and keywords to all crate manifests

### DIFF
--- a/archelon-cli/Cargo.toml
+++ b/archelon-cli/Cargo.toml
@@ -5,6 +5,8 @@ version.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
+categories = ["command-line-utilities", "text-processing"]
+keywords = ["markdown", "task-management", "notes", "cli", "todo"]
 
 [[bin]]
 name = "archelon"

--- a/archelon-core/Cargo.toml
+++ b/archelon-core/Cargo.toml
@@ -5,6 +5,8 @@ version.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
+categories = ["text-processing", "filesystem", "data-structures"]
+keywords = ["markdown", "task-management", "notes", "frontmatter", "plain-text"]
 
 [dependencies]
 caretta-id = { version = "0.10", features = ["serde"] }

--- a/archelon-mcp/Cargo.toml
+++ b/archelon-mcp/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 description = "MCP server for archelon"
 license.workspace = true
 repository.workspace = true
+categories = ["command-line-utilities", "text-processing"]
+keywords = ["markdown", "task-management", "notes", "mcp", "mcp-server"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target_os }-{ target_arch }{ binary-ext }"


### PR DESCRIPTION
## Summary

- Add `categories` and `keywords` to `archelon-core`, `archelon-cli`, and `archelon-mcp` Cargo.toml manifests
- Improves discoverability on crates.io

| Crate | categories | keywords |
|---|---|---|
| `archelon-core` | `text-processing`, `filesystem`, `data-structures` | `markdown`, `task-management`, `notes`, `frontmatter`, `plain-text` |
| `archelon-cli` | `command-line-utilities`, `text-processing` | `markdown`, `task-management`, `notes`, `cli`, `todo` |
| `archelon-mcp` | `command-line-utilities`, `text-processing` | `markdown`, `task-management`, `notes`, `mcp`, `mcp-server` |

All categories are from the [official crates.io category slugs](https://crates.io/category_slugs). Keywords are within the 5-per-crate and 20-character-per-keyword limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)