### PR TITLE
feat: typed EntryRef IDs, unified EntryFields, and parent entry support

### DIFF
--- a/archelon-core/src/cache.rs
+++ b/archelon-core/src/cache.rs
@@ -343,58 +343,23 @@ pub fn sync_cache(journal: &Journal, conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Look up an entry by ID string.
+/// Look up an entry by its [`CarettaId`].
 ///
-/// - **Full 7-char ID**: parsed as `CarettaId` and looked up by INTEGER primary key.
-/// - **Prefix (< 7 chars)**: all IDs are fetched and filtered client-side.
-///   This is a transitional fallback; the preferred UX is autocomplete over the
-///   full ID list rather than server-side prefix queries.
-///
-/// If a stored path no longer exists on disk, the stale row is removed and
+/// If the stored path no longer exists on disk, the stale row is removed and
 /// [`Error::EntryNotFound`] is returned.
-pub fn find_entry_by_id(conn: &Connection, id_input: &str) -> Result<PathBuf> {
-    // Fast path: full CarettaId → exact INTEGER lookup.
-    if let Ok(id) = id_input.parse::<CarettaId>() {
-        return match conn.query_row(
-            "SELECT path FROM entries WHERE id = ?1",
-            [id],
-            |row| row.get::<_, String>(0),
-        ) {
-            Ok(path_str) => {
-                let path = PathBuf::from(&path_str);
-                if !path.exists() {
-                    conn.execute("DELETE FROM entries WHERE id = ?1", [id])?;
-                    return Err(Error::EntryNotFound(id_input.to_owned()));
-                }
-                Ok(path)
+pub fn find_entry_by_id(conn: &Connection, id: CarettaId) -> Result<crate::entry::Entry> {
+    match fetch_full_entry(conn, id) {
+        Ok(entry) => {
+            if !entry.path.exists() {
+                conn.execute("DELETE FROM entries WHERE id = ?1", [id])?;
+                return Err(Error::EntryNotFound(id.to_string()));
             }
-            Err(rusqlite::Error::QueryReturnedNoRows) => {
-                Err(Error::EntryNotFound(id_input.to_owned()))
-            }
-            Err(e) => Err(Error::Cache(e)),
-        };
-    }
-
-    // Prefix fallback: client-side filtering over all IDs.
-    let mut stmt = conn.prepare("SELECT id, path FROM entries")?;
-    let matches: Vec<(CarettaId, String)> = stmt
-        .query_map([], |row| Ok((row.get::<_, CarettaId>(0)?, row.get::<_, String>(1)?)))?
-        .collect::<rusqlite::Result<Vec<_>>>()?
-        .into_iter()
-        .filter(|(id, _)| id.to_string().starts_with(id_input))
-        .collect();
-
-    match matches.len() {
-        0 => Err(Error::EntryNotFound(id_input.to_owned())),
-        1 => {
-            let path = PathBuf::from(&matches[0].1);
-            if !path.exists() {
-                conn.execute("DELETE FROM entries WHERE id = ?1", [matches[0].0])?;
-                return Err(Error::EntryNotFound(id_input.to_owned()));
-            }
-            Ok(path)
+            Ok(entry)
         }
-        n => Err(Error::AmbiguousId(id_input.to_owned(), n)),
+        Err(Error::Cache(rusqlite::Error::QueryReturnedNoRows)) => {
+            Err(Error::EntryNotFound(id.to_string()))
+        }
+        Err(e) => Err(e),
     }
 }
 
@@ -405,21 +370,24 @@ pub fn find_entry_by_id(conn: &Connection, id_input: &str) -> Result<PathBuf> {
 ///
 /// If the matched path no longer exists on disk the stale row is removed and
 /// [`Error::EntryNotFoundByTitle`] is returned.
-pub fn find_entry_by_title(conn: &Connection, title: &str) -> Result<PathBuf> {
-    let mut stmt = conn.prepare("SELECT path FROM entries WHERE title = ?1")?;
-    let paths: Vec<String> = stmt
-        .query_map([title], |row| row.get::<_, String>(0))?
+pub fn find_entry_by_title(
+    conn: &Connection,
+    title: &str,
+) -> Result<crate::entry::Entry> {
+    let mut stmt = conn.prepare("SELECT id, path FROM entries WHERE title = ?1")?;
+    let rows: Vec<(CarettaId, String)> = stmt
+        .query_map([title], |row| Ok((row.get::<_, CarettaId>(0)?, row.get::<_, String>(1)?)))?
         .collect::<rusqlite::Result<Vec<_>>>()?;
 
-    match paths.len() {
+    match rows.len() {
         0 => Err(Error::EntryNotFoundByTitle(title.to_owned())),
         1 => {
-            let path = PathBuf::from(&paths[0]);
-            if !path.exists() {
-                conn.execute("DELETE FROM files WHERE path = ?1", [&paths[0]])?;
+            let (id, path_str) = rows.into_iter().next().unwrap();
+            if !PathBuf::from(&path_str).exists() {
+                conn.execute("DELETE FROM files WHERE path = ?1", [&path_str])?;
                 return Err(Error::EntryNotFoundByTitle(title.to_owned()));
             }
-            Ok(path)
+            fetch_full_entry(conn, id)
         }
         n => Err(Error::AmbiguousTitle(title.to_owned(), n)),
     }
@@ -591,6 +559,95 @@ pub fn upsert_entry_from_path(conn: &Connection, path: &Path) -> Result<()> {
 }
 
 // ── internals ─────────────────────────────────────────────────────────────────
+
+/// Fetch a single entry (all columns + tags) from the cache by its numeric ID.
+///
+/// Returns `Error::Cache(QueryReturnedNoRows)` if no row exists.
+fn fetch_full_entry(
+    conn: &Connection,
+    id: CarettaId,
+) -> Result<crate::entry::Entry> {
+    use chrono::NaiveDateTime;
+    use indexmap::IndexMap;
+    use crate::entry::{Entry, EventMeta, Frontmatter, TaskMeta};
+
+    let (parent_id, path_str, title, slug, created_at, updated_at,
+         is_task, task_status, task_due, task_started_at, task_closed_at,
+         is_event, event_start, event_end, body) = conn.query_row(
+        "SELECT parent_id, path, title, slug, created_at, updated_at,
+                is_task, task_status, task_due, task_started_at, task_closed_at,
+                is_event, event_start, event_end, body
+         FROM entries WHERE id = ?1",
+        [id],
+        |row| {
+            Ok((
+                row.get::<_, Option<CarettaId>>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+                row.get::<_, String>(5)?,
+                row.get::<_, i32>(6)?,
+                row.get::<_, Option<String>>(7)?,
+                row.get::<_, Option<String>>(8)?,
+                row.get::<_, Option<String>>(9)?,
+                row.get::<_, Option<String>>(10)?,
+                row.get::<_, i32>(11)?,
+                row.get::<_, Option<String>>(12)?,
+                row.get::<_, Option<String>>(13)?,
+                row.get::<_, String>(14)?,
+            ))
+        },
+    )?;
+
+    let mut tags_stmt = conn.prepare("SELECT tag FROM tags WHERE entry_id = ?1 ORDER BY tag")?;
+    let tags: Vec<String> = tags_stmt
+        .query_map([id], |row| row.get(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+
+    let parse_dt = |s: &str| {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M").unwrap_or_default()
+    };
+    let parse_dt_opt = |s: Option<String>| -> Option<NaiveDateTime> {
+        s.as_deref().and_then(|s| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M").ok())
+    };
+
+    let task = if is_task != 0 {
+        Some(TaskMeta {
+            status: task_status.unwrap_or_else(|| "open".to_owned()),
+            due: parse_dt_opt(task_due),
+            started_at: parse_dt_opt(task_started_at),
+            closed_at: parse_dt_opt(task_closed_at),
+            extra: IndexMap::new(),
+        })
+    } else {
+        None
+    };
+
+    let event = if is_event != 0 {
+        match (parse_dt_opt(event_start), parse_dt_opt(event_end)) {
+            (Some(start), Some(end)) => Some(EventMeta { start, end, extra: IndexMap::new() }),
+            _ => None,
+        }
+    } else {
+        None
+    };
+
+    let frontmatter = Frontmatter {
+        id,
+        parent_id,
+        title,
+        slug,
+        tags,
+        created_at: parse_dt(&created_at),
+        updated_at: parse_dt(&updated_at),
+        task,
+        event,
+        extra: IndexMap::new(),
+    };
+
+    Ok(Entry { path: PathBuf::from(path_str), frontmatter, body })
+}
 
 fn collect_with_mtime(journal: &Journal) -> Result<Vec<(PathBuf, i64)>> {
     let paths = journal.collect_entries()?;

--- a/archelon-core/src/entry_ref.rs
+++ b/archelon-core/src/entry_ref.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use caretta_id::CarettaId;
+
 /// A reference to a journal entry — a filesystem path, a CarettaId, or a title.
 ///
 /// This is the canonical input type for commands that operate on a single entry
@@ -10,20 +12,22 @@ use std::path::PathBuf;
 ///
 /// | Input form              | Resolved as     |
 /// |-------------------------|-----------------|
-/// | `@abc1234`              | `Id("abc1234")` |
+/// | `@abc1234`              | `Id(CarettaId)` |
 /// | `path/to/file.md`       | `Path(...)`     |
 /// | `./relative.md`         | `Path(...)`     |
 /// | `~/absolute.md`         | `Path(...)`     |
 /// | `anything_else`         | `Title(...)`    |
 ///
 /// The `@` prefix is required for IDs to avoid ambiguity with titles that
-/// happen to be 7 alphanumeric characters.
+/// happen to be 7 alphanumeric characters.  If the part after `@` cannot be
+/// parsed as a valid [`CarettaId`], the `@` is treated as part of the string
+/// and the usual path/title heuristics apply.
 #[derive(Debug, Clone)]
 pub enum EntryRef {
     /// A filesystem path to the entry file.
     Path(PathBuf),
-    /// A CarettaId (the `@` prefix has been stripped).
-    Id(String),
+    /// A fully-parsed CarettaId (the `@` prefix has been stripped and validated).
+    Id(CarettaId),
     /// An exact entry title (case-sensitive).
     Title(String),
 }
@@ -31,13 +35,18 @@ pub enum EntryRef {
 impl EntryRef {
     /// Classify a raw CLI string as a path, an ID, or a title.
     ///
-    /// - Starts with `@` → [`EntryRef::Id`] (prefix stripped).
+    /// - Starts with `@` **and** the remainder parses as a [`CarettaId`]
+    ///   → [`EntryRef::Id`].
     /// - Contains `/` or `\`, starts with `.` or `~`, or ends with `.md`
     ///   → [`EntryRef::Path`].
-    /// - Anything else → [`EntryRef::Title`].
+    /// - Anything else (including `@foo` where `foo` is not a valid CarettaId)
+    ///   → [`EntryRef::Title`].
     pub fn parse(s: &str) -> Self {
-        if let Some(id) = s.strip_prefix('@') {
-            return EntryRef::Id(id.to_owned());
+        if let Some(rest) = s.strip_prefix('@') {
+            if let Ok(id) = rest.parse::<CarettaId>() {
+                return EntryRef::Id(id);
+            }
+            // Invalid CarettaId after `@` — fall through to path/title heuristics.
         }
         if s.contains('/')
             || s.contains(std::path::MAIN_SEPARATOR)

--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -10,6 +10,7 @@ use indexmap::IndexMap;
 
 use caretta_id::CarettaId;
 use chrono::{Datelike as _, NaiveDateTime};
+use rusqlite::Connection;
 
 use crate::{
     cache,
@@ -433,10 +434,17 @@ fn cmp_opt<T: Ord>(a: Option<T>, b: Option<T>) -> Ordering {
 
 /// Parsed frontmatter fields used for creating or updating an entry.
 ///
-/// All fields are optional. `title` is passed separately to [`create_entry`]
-/// (required) and [`update_entry`] (optional).
+/// All fields are optional.  For [`create_entry`], `title` defaults to an
+/// empty string when `None`; `body` defaults to empty.  For [`update_entry`],
+/// `None` means "leave unchanged".
 #[derive(Debug, Default)]
 pub struct EntryFields {
+    pub title: Option<String>,
+    pub body: Option<String>,
+    /// Parent entry reference.  Resolved to a `CarettaId` via the cache at
+    /// write time.  `None` means "leave parent unchanged" in update; "no
+    /// parent" in create.
+    pub parent: Option<EntryRef>,
     pub slug: Option<String>,
     /// `None` = leave tags unchanged; `Some([])` = clear all tags.
     pub tags: Option<Vec<String>>,
@@ -450,18 +458,45 @@ pub struct EntryFields {
 
 // ── create ────────────────────────────────────────────────────────────────────
 
-/// Create a new entry in `journal` with the given `title`, `body`, and `fields`.
+/// Create a new entry in `journal` with the given `fields`.
 ///
-/// Returns the path of the newly created file.
-/// Fails with [`Error::EntryAlreadyExists`] if the destination already exists.
-pub fn create_entry(
-    journal: &Journal,
-    title: &str,
-    body: String,
-    fields: EntryFields,
-) -> Result<PathBuf> {
+/// `fields.title` defaults to `""` when `None`; `fields.body` defaults to `""`.
+///
+/// Fails with:
+/// - [`Error::DuplicateTitle`] if another entry already has the same title.
+/// - [`Error::DuplicateId`] if the generated ID already exists in the cache
+///   (extremely rare in practice).
+/// - [`Error::EntryAlreadyExists`] if the destination file already exists on disk.
+/// - [`Error::EntryNotFound`] / [`Error::EntryNotFoundByTitle`] if `fields.parent`
+///   cannot be resolved.
+pub fn create_entry(journal: &Journal, conn: &Connection, fields: EntryFields) -> Result<PathBuf> {
     let id = CarettaId::now_unix();
     let year = chrono::Local::now().year();
+
+    let title = fields.title.unwrap_or_default();
+    let body = fields.body.unwrap_or_default();
+
+    // ── duplicate title check ──────────────────────────────────────────────
+    if !title.is_empty() {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM entries WHERE title = ?1",
+            [&title],
+            |row| row.get(0),
+        )?;
+        if count > 0 {
+            return Err(Error::DuplicateTitle(title));
+        }
+    }
+
+    // ── duplicate ID check (rare; IDs are time-based) ──────────────────────
+    let id_count: i64 =
+        conn.query_row("SELECT COUNT(*) FROM entries WHERE id = ?1", [id], |row| row.get(0))?;
+    if id_count > 0 {
+        return Err(Error::DuplicateId(id.to_string(), "<new>".to_owned(), "<cache>".to_owned()));
+    }
+
+    // ── resolve parent ─────────────────────────────────────────────────────
+    let parent_id = resolve_parent_id(conn, fields.parent.as_ref())?;
 
     let tags = fields.tags.unwrap_or_default();
 
@@ -495,8 +530,8 @@ pub fn create_entry(
     let now = chrono::Local::now().naive_local();
     let frontmatter = Frontmatter {
         id,
-        parent_id: None,
-        title: title.to_owned(),
+        parent_id,
+        title,
         slug: fields.slug.unwrap_or_default(),
         tags,
         created_at: now,
@@ -527,14 +562,32 @@ pub fn create_entry(
 /// `updated_at` is refreshed automatically by [`write_entry`].
 /// If the title or slug changed, the file is also renamed to match the new
 /// canonical filename.  Returns `Some(new_path)` when renamed, `None` otherwise.
-pub fn update_entry(path: &Path, title: Option<String>, body: Option<String>, fields: EntryFields) -> Result<Option<PathBuf>> {
+///
+/// Fails with [`Error::DuplicateTitle`] if another entry already uses the new
+/// title.  Fails with [`Error::EntryNotFound`] / [`Error::EntryNotFoundByTitle`]
+/// if `fields.parent` cannot be resolved.
+pub fn update_entry(path: &Path, conn: &Connection, fields: EntryFields) -> Result<Option<PathBuf>> {
     let mut entry = read_entry(path)?;
 
-    if let Some(t) = title {
+    if let Some(t) = fields.title {
+        // ── duplicate title check (exclude current entry) ──────────────────
+        if t != entry.frontmatter.title && !t.is_empty() {
+            let count: i64 = conn.query_row(
+                "SELECT COUNT(*) FROM entries WHERE title = ?1 AND id != ?2",
+                rusqlite::params![t, entry.frontmatter.id],
+                |row| row.get(0),
+            )?;
+            if count > 0 {
+                return Err(Error::DuplicateTitle(t));
+            }
+        }
         entry.frontmatter.title = t;
     }
-    if let Some(b) = body {
+    if let Some(b) = fields.body {
         entry.body = b;
+    }
+    if let Some(parent_ref) = fields.parent.as_ref() {
+        entry.frontmatter.parent_id = Some(resolve_parent_id(conn, Some(parent_ref))?.unwrap());
     }
     if let Some(s) = fields.slug {
         entry.frontmatter.slug = s;
@@ -594,6 +647,21 @@ pub fn update_entry(path: &Path, title: Option<String>, body: Option<String>, fi
     fix_entry_mut(&mut entry, true)
 }
 
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Resolve an optional [`EntryRef`] to the corresponding `CarettaId` by looking
+/// up the entry in the cache.  Returns `Ok(None)` when `parent` is `None`.
+fn resolve_parent_id(conn: &Connection, parent: Option<&EntryRef>) -> Result<Option<CarettaId>> {
+    match parent {
+        None => Ok(None),
+        Some(EntryRef::Id(id)) => Ok(Some(*id)),
+        Some(EntryRef::Path(path)) => Ok(Some(read_entry(path)?.frontmatter.id)),
+        Some(EntryRef::Title(title)) => {
+            Ok(Some(cache::find_entry_by_title(conn, title)?.frontmatter.id))
+        }
+    }
+}
+
 // ── prepare new (for editor workflow) ─────────────────────────────────────────
 
 /// Create a new entry file with a frontmatter template in the journal's year directory.
@@ -647,13 +715,13 @@ pub fn resolve_entry(entry_ref: &EntryRef, journal_dir: Option<&Path>) -> Result
             let journal = open_journal_for_resolve(journal_dir)?;
             let conn = cache::open_cache(&journal)?;
             cache::sync_cache(&journal, &conn)?;
-            cache::find_entry_by_id(&conn, id)
+            cache::find_entry_by_id(&conn, *id).map(|e| e.path)
         }
         EntryRef::Title(title) => {
             let journal = open_journal_for_resolve(journal_dir)?;
             let conn = cache::open_cache(&journal)?;
             cache::sync_cache(&journal, &conn)?;
-            cache::find_entry_by_title(&conn, title)
+            cache::find_entry_by_title(&conn, title).map(|e| e.path)
         }
     }
 }

--- a/archelon/src/commands/entry.rs
+++ b/archelon/src/commands/entry.rs
@@ -189,6 +189,10 @@ pub struct EntryFields {
     #[arg(long, short)]
     pub body: Option<String>,
 
+    /// Parent entry — accepts `@ID`, a file path, or a title.
+    #[arg(long, value_name = "ENTRY")]
+    pub parent: Option<String>,
+
     /// Slug override in the frontmatter
     #[arg(long)]
     pub slug: Option<String>,
@@ -225,6 +229,9 @@ pub struct EntryFields {
 impl From<EntryFields> for CoreEntryFields {
     fn from(f: EntryFields) -> Self {
         Self {
+            title: f.title,
+            body: f.body,
+            parent: f.parent.as_deref().map(EntryRef::parse),
             slug: f.slug,
             tags: f.tags,
             task_due: f.task_due,
@@ -462,12 +469,10 @@ fn show(path: &Path) -> Result<()> {
 
 fn new(journal_dir: Option<&Path>, fields: EntryFields) -> Result<()> {
     let journal = open_journal(journal_dir)?;
-    let title = fields.title.clone().unwrap_or_default();
-    let body = fields.body.clone().unwrap_or_default();
-    let dest = ops::create_entry(&journal, &title, body, fields.into())?;
-    if let Ok(conn) = cache::open_cache(&journal) {
-        let _ = cache::upsert_entry_from_path(&conn, &dest);
-    }
+    let conn = cache::open_cache(&journal)?;
+    cache::sync_cache(&journal, &conn)?;
+    let dest = ops::create_entry(&journal, &conn, fields.into())?;
+    let _ = cache::upsert_entry_from_path(&conn, &dest);
     println!("created: {}", dest.display());
     Ok(())
 }
@@ -527,6 +532,7 @@ fn edit_new(journal_dir: Option<&Path>) -> Result<()> {
 fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<()> {
     if fields.title.is_none()
         && fields.body.is_none()
+        && fields.parent.is_none()
         && fields.slug.is_none()
         && fields.tags.is_none()
         && fields.task_due.is_none()
@@ -538,16 +544,12 @@ fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<(
     {
         bail!("nothing to update — specify at least one field");
     }
-    let _ = journal_dir; // reserved for future use
-    let title = fields.title.clone();
-    let body = fields.body.clone();
-    let new_path_opt = ops::update_entry(path, title, body, fields.into())?;
+    let journal = open_journal(journal_dir)?;
+    let conn = cache::open_cache(&journal)?;
+    cache::sync_cache(&journal, &conn)?;
+    let new_path_opt = ops::update_entry(path, &conn, fields.into())?;
     let final_path = new_path_opt.as_deref().unwrap_or(path);
-    if let Ok(journal) = open_journal(journal_dir) {
-        if let Ok(conn) = cache::open_cache(&journal) {
-            let _ = cache::upsert_entry_from_path(&conn, final_path);
-        }
-    }
+    let _ = cache::upsert_entry_from_path(&conn, final_path);
     if let Some(new_path) = new_path_opt {
         println!("updated and renamed: {}", new_path.display());
     } else {

--- a/archelon/src/commands/mcp.rs
+++ b/archelon/src/commands/mcp.rs
@@ -123,9 +123,11 @@ struct EntryShowParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct EntryNewParams {
     /// Title of the entry — written into the frontmatter and used to generate the filename slug
-    title: String,
+    title: Option<String>,
     /// Body content (Markdown)
-    body: String,
+    body: Option<String>,
+    /// Parent entry — accepts `@ID`, a file path, or an exact title
+    parent: Option<String>,
     /// Slug override in the frontmatter
     slug: Option<String>,
     /// Tags as comma-separated string (e.g. "work,project")
@@ -152,6 +154,8 @@ struct EntrySetParams {
     title: Option<String>,
     /// New body content (Markdown). Replaces the existing body.
     body: Option<String>,
+    /// New parent entry — accepts `@ID`, a file path, or an exact title
+    parent: Option<String>,
     /// New slug override
     slug: Option<String>,
     /// New tags as comma-separated string. Pass empty string to clear all tags.
@@ -204,6 +208,9 @@ fn parse_entry_fields(
     event_end: Option<&str>,
 ) -> anyhow::Result<EntryFields> {
     Ok(EntryFields {
+        title: None,
+        body: None,
+        parent: None,
         slug,
         tags: tags.as_deref().map(|s| {
             s.split(',')
@@ -446,7 +453,16 @@ impl ArchelonServer {
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),
             )?;
-            let dest = ops::create_entry(&journal, &p.title, p.body, fields)?;
+            let conn = cache::open_cache(&journal)?;
+            cache::sync_cache(&journal, &conn)?;
+            let fields = EntryFields {
+                title: p.title,
+                body: p.body,
+                parent: p.parent.as_deref().map(EntryRef::parse),
+                ..fields
+            };
+            let dest = ops::create_entry(&journal, &conn, fields)?;
+            let _ = cache::upsert_entry_from_path(&conn, &dest);
             Ok(format!("created: {}", dest.display()))
         })()
         .map_err(|e| e.to_string())
@@ -480,9 +496,20 @@ impl ArchelonServer {
                 p.event_start.as_deref(),
                 p.event_end.as_deref(),
             )?;
-            let msg = if let Some(new_path) = ops::update_entry(&path, p.title, p.body, fields)? {
+            let journal = self.open_journal()?;
+            let conn = cache::open_cache(&journal)?;
+            cache::sync_cache(&journal, &conn)?;
+            let fields = EntryFields {
+                title: p.title,
+                body: p.body,
+                parent: p.parent.as_deref().map(EntryRef::parse),
+                ..fields
+            };
+            let msg = if let Some(new_path) = ops::update_entry(&path, &conn, fields)? {
+                let _ = cache::upsert_entry_from_path(&conn, &new_path);
                 format!("updated and renamed: {}", new_path.display())
             } else {
+                let _ = cache::upsert_entry_from_path(&conn, &path);
                 format!("updated: {}", path.display())
             };
             Ok(msg)


### PR DESCRIPTION
## Summary

- **Typed `EntryRef::Id`**: `Id` variant now holds `CarettaId` instead of `String`; `@`-prefixed input is validated at parse time and falls through to path/title heuristics on failure
- **`find_entry_by_id` / `find_entry_by_title` return `Entry`**: removed `PathBuf`-only return; added `fetch_full_entry` private helper shared by both lookups
- **Unified `EntryFields`**: moved `title` and `body` into `EntryFields` alongside new `parent: Option<EntryRef>`; `create_entry` / `update_entry` signatures simplified accordingly
- **Duplicate checks and parent resolution at write time**: both create and update now take `&Connection`, check for duplicate title/ID, and resolve the parent `EntryRef` to a `CarettaId` before writing
- **`--parent` / `parent` exposed in CLI and MCP**: accepts `@ID`, file path, or exact title; MCP `EntryNewParams.title`/`body` made optional

## Test plan

- [ ] `archelon entry new --title "child" --parent @<id>` creates an entry with `parent_id` set
- [ ] `archelon entry set @<id> --parent @<parent-id>` updates `parent_id`
- [ ] Creating an entry with a duplicate title returns `DuplicateTitle` error
- [ ] An `@`-prefixed string that is not a valid `CarettaId` falls through to title matching
- [ ] MCP `entry_new` / `entry_set` with `"parent"` field resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)