### PR TITLE
feat(vscode): add drag-and-drop reparenting in tree view

### DIFF
--- a/archelon-vscode/src/cli.ts
+++ b/archelon-vscode/src/cli.ts
@@ -78,6 +78,14 @@ export async function removeEntry(entry: string, cwd: string): Promise<void> {
     await execFileAsync(bin(), ['entry', 'remove', entry], { cwd });
 }
 
+/**
+ * Run `archelon entry set <entryPath> --parent @<parentId>`.
+ * Throws on non-zero exit.
+ */
+export async function setEntryParent(entryPath: string, parentId: string, cwd: string): Promise<void> {
+    await execFileAsync(bin(), ['entry', 'set', entryPath, '--parent', `@${parentId}`], { cwd });
+}
+
 export interface EntryRecord {
     id: string;
     path: string;

--- a/archelon-vscode/src/entryTreeProvider.ts
+++ b/archelon-vscode/src/entryTreeProvider.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { EntryRecord, SortField, SortOrder, listEntries, treeEntries } from './cli';
+import { EntryRecord, SortField, SortOrder, listEntries, setEntryParent, treeEntries } from './cli';
 import { findJournalRoot } from './journal';
 
 export type ViewMode = 'tree' | 'list';
@@ -58,7 +58,11 @@ export class EntryItem extends vscode.TreeItem {
     }
 }
 
-export class EntryTreeProvider implements vscode.TreeDataProvider<EntryItem> {
+const ENTRY_MIME_TYPE = 'application/vnd.code.tree.archelon.entries';
+
+export class EntryTreeProvider implements vscode.TreeDataProvider<EntryItem>, vscode.TreeDragAndDropController<EntryItem> {
+    readonly dragMimeTypes = [ENTRY_MIME_TYPE];
+    readonly dropMimeTypes = [ENTRY_MIME_TYPE];
     private _onDidChangeTreeData = new vscode.EventEmitter<EntryItem | undefined | void>();
     readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
@@ -135,6 +139,36 @@ export class EntryTreeProvider implements vscode.TreeDataProvider<EntryItem> {
         }
 
         return this._toItems(roots);
+    }
+
+    handleDrag(source: readonly EntryItem[], dataTransfer: vscode.DataTransfer): void {
+        dataTransfer.set(ENTRY_MIME_TYPE, new vscode.DataTransferItem(
+            source.map(s => ({ id: s.record.id, path: s.record.path }))
+        ));
+    }
+
+    async handleDrop(target: EntryItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+        if (!target) { return; }
+        const item = dataTransfer.get(ENTRY_MIME_TYPE);
+        if (!item) { return; }
+        const sources: { id: string; path: string }[] = item.value;
+
+        const cwd = this._getCwd();
+        if (!cwd) { return; }
+
+        const errors: string[] = [];
+        for (const src of sources) {
+            if (src.id === target.record.id) { continue; }
+            try {
+                await setEntryParent(src.path, target.record.id, cwd);
+            } catch (err) {
+                errors.push(`@${src.id}: ${err}`);
+            }
+        }
+        if (errors.length > 0) {
+            vscode.window.showErrorMessage(`Archelon: failed to reparent — ${errors.join(', ')}`);
+        }
+        this.refresh();
     }
 
     private _toItems(records: EntryRecord[]): EntryItem[] {

--- a/archelon-vscode/src/extension.ts
+++ b/archelon-vscode/src/extension.ts
@@ -21,6 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
     const treeProvider = new EntryTreeProvider();
     const treeView = vscode.window.createTreeView('archelon.entries', {
         treeDataProvider: treeProvider,
+        dragAndDropController: treeProvider,
         showCollapseAll: false,
     });
     context.subscriptions.push(treeView);


### PR DESCRIPTION
## Summary

- `EntryTreeProvider` now implements `TreeDragAndDropController<EntryItem>`, enabling drag-and-drop to change an entry's parent in the tree view
- On drop, calls `archelon entry set <path> --parent @<id>` to update the parent
- Added `setEntryParent(entryPath, parentId, cwd)` helper to `cli.ts`

## Test plan

- [ ] Drag an entry onto another entry — it should become a child of the target
- [ ] Tree refreshes automatically after a successful drop
- [ ] Dropping an entry onto itself is a no-op
- [ ] Dropping a parent onto its own descendant (circular reference) shows an error message from the CLI

## Notes

Dropping onto empty space (to unset parent / move to root) is not yet supported, as the CLI has no way to unset `parent_id` via `entry set`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)