### PR TITLE
feat: add UpdateOption<T> and --no-parent flag to entry set

### DIFF
--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -22,6 +22,19 @@ use crate::{
     period::Period,
 };
 
+// ── UpdateOption ──────────────────────────────────────────────────────────────
+
+/// Represents the three possible states for an optional field in an update
+/// operation: set it to a new value, clear it (set to `None`), or leave it
+/// unchanged.
+#[derive(Debug, Default)]
+pub enum UpdateOption<T> {
+    Set(T),
+    Clear,
+    #[default]
+    Unchanged,
+}
+
 // ── SortField / SortOrder ─────────────────────────────────────────────────────
 
 /// Which field to sort entries by in [`list_entries`].
@@ -436,9 +449,9 @@ pub struct EntryFields {
     pub title: Option<String>,
     pub body: Option<String>,
     /// Parent entry reference.  Resolved to a `CarettaId` via the cache at
-    /// write time.  `None` means "leave parent unchanged" in update; "no
-    /// parent" in create.
-    pub parent: Option<EntryRef>,
+    /// write time.  `Unchanged` means "leave parent unchanged" in update; "no
+    /// parent" in create.  `Clear` sets `parent_id` to `None`.
+    pub parent: UpdateOption<EntryRef>,
     pub slug: Option<String>,
     /// `None` = leave tags unchanged; `Some([])` = clear all tags.
     pub tags: Option<Vec<String>>,
@@ -490,7 +503,10 @@ pub fn create_entry(journal: &Journal, conn: &Connection, fields: EntryFields) -
     }
 
     // ── resolve parent ─────────────────────────────────────────────────────
-    let parent_id = resolve_parent_id(conn, fields.parent.as_ref())?;
+    let parent_id = match &fields.parent {
+        UpdateOption::Set(r) => resolve_parent_id(conn, Some(r))?,
+        UpdateOption::Clear | UpdateOption::Unchanged => None,
+    };
 
     let tags = fields.tags.unwrap_or_default();
 
@@ -580,8 +596,14 @@ pub fn update_entry(path: &Path, conn: &Connection, fields: EntryFields) -> Resu
     if let Some(b) = fields.body {
         entry.body = b;
     }
-    if let Some(parent_ref) = fields.parent.as_ref() {
-        entry.frontmatter.parent_id = Some(resolve_parent_id(conn, Some(parent_ref))?.unwrap());
+    match &fields.parent {
+        UpdateOption::Set(r) => {
+            entry.frontmatter.parent_id = Some(resolve_parent_id(conn, Some(r))?.unwrap());
+        }
+        UpdateOption::Clear => {
+            entry.frontmatter.parent_id = None;
+        }
+        UpdateOption::Unchanged => {}
     }
     if let Some(s) = fields.slug {
         entry.frontmatter.slug = s;

--- a/archelon/src/commands/entry.rs
+++ b/archelon/src/commands/entry.rs
@@ -3,7 +3,7 @@ use archelon_core::{
     cache,
     entry_ref::EntryRef,
     journal::{Journal, WeekStart},
-    ops::{self, EntryFields as CoreEntryFields, EntryFilter, EntryTreeNode, FieldSelector, MatchLabel, SortField, SortOrder},
+    ops::{self, EntryFields as CoreEntryFields, EntryFilter, EntryTreeNode, FieldSelector, MatchLabel, SortField, SortOrder, UpdateOption},
     period::{parse_datetime, parse_datetime_end, parse_period},
 };
 
@@ -151,6 +151,10 @@ pub enum EntryCommand {
 
         #[command(flatten)]
         fields: EntryFields,
+
+        /// Remove the parent relationship (make this a root entry)
+        #[arg(long, conflicts_with = "parent")]
+        no_parent: bool,
     },
     /// Check whether an entry's frontmatter and filename are valid
     Check {
@@ -246,7 +250,10 @@ impl From<EntryFields> for CoreEntryFields {
         Self {
             title: f.title,
             body: f.body,
-            parent: f.parent.as_deref().map(EntryRef::parse),
+            parent: match f.parent.as_deref() {
+                Some(s) => UpdateOption::Set(EntryRef::parse(s)),
+                None => UpdateOption::Unchanged,
+            },
             slug: f.slug,
             tags: f.tags,
             task_due: f.task_due,
@@ -286,7 +293,7 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
                 bail!("specify an entry or use --new to create one")
             }
         }
-        EntryCommand::Set { entry, fields } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields),
+        EntryCommand::Set { entry, fields, no_parent } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields, no_parent),
         EntryCommand::Check { entry } => check(journal_dir, &entry),
         EntryCommand::Fix { entry, touch } => fix(journal_dir, &entry, touch),
         EntryCommand::Path { entry, new, parent } => entry_path(journal_dir, entry.as_deref(), new, parent.as_deref()),
@@ -582,7 +589,7 @@ fn edit_new(journal_dir: Option<&Path>) -> Result<()> {
 
 // ── set ───────────────────────────────────────────────────────────────────────
 
-fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<()> {
+fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields, no_parent: bool) -> Result<()> {
     if fields.title.is_none()
         && fields.body.is_none()
         && fields.parent.is_none()
@@ -594,13 +601,18 @@ fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields) -> Result<(
         && fields.task_closed_at.is_none()
         && fields.event_start.is_none()
         && fields.event_end.is_none()
+        && !no_parent
     {
         bail!("nothing to update — specify at least one field");
     }
     let journal = open_journal(journal_dir)?;
     let conn = cache::open_cache(&journal)?;
     cache::sync_cache(&journal, &conn)?;
-    let new_path_opt = ops::update_entry(path, &conn, fields.into())?;
+    let mut core_fields: CoreEntryFields = fields.into();
+    if no_parent {
+        core_fields.parent = UpdateOption::Clear;
+    }
+    let new_path_opt = ops::update_entry(path, &conn, core_fields)?;
     let final_path = new_path_opt.as_deref().unwrap_or(path);
     let _ = cache::upsert_entry_from_path(&conn, final_path);
     if let Some(new_path) = new_path_opt {

--- a/archelon/src/commands/mcp.rs
+++ b/archelon/src/commands/mcp.rs
@@ -6,7 +6,7 @@ use archelon_core::{
     emoji,
     entry_ref::EntryRef,
     journal::{Journal, WeekStart},
-    ops::{self, EntryFields, EntryFilter, EntryTreeNode, FieldSelector, SortField, SortOrder},
+    ops::{self, EntryFields, EntryFilter, EntryTreeNode, FieldSelector, SortField, SortOrder, UpdateOption},
     parser::read_entry,
     period::{parse_datetime, parse_datetime_end, parse_period},
 };
@@ -211,7 +211,7 @@ fn parse_entry_fields(
     Ok(EntryFields {
         title: None,
         body: None,
-        parent: None,
+        parent: UpdateOption::Unchanged,
         slug,
         tags: tags.as_deref().map(|s| {
             s.split(',')
@@ -471,7 +471,10 @@ impl ArchelonServer {
             let fields = EntryFields {
                 title: p.title,
                 body: p.body,
-                parent: p.parent.as_deref().map(EntryRef::parse),
+                parent: match p.parent.as_deref() {
+                    Some(s) => UpdateOption::Set(EntryRef::parse(s)),
+                    None => UpdateOption::Unchanged,
+                },
                 ..fields
             };
             let dest = ops::create_entry(&journal, &conn, fields)?;
@@ -515,7 +518,10 @@ impl ArchelonServer {
             let fields = EntryFields {
                 title: p.title,
                 body: p.body,
-                parent: p.parent.as_deref().map(EntryRef::parse),
+                parent: match p.parent.as_deref() {
+                    Some(s) => UpdateOption::Set(EntryRef::parse(s)),
+                    None => UpdateOption::Unchanged,
+                },
                 ..fields
             };
             let msg = if let Some(new_path) = ops::update_entry(&path, &conn, fields)? {


### PR DESCRIPTION
## Summary

- Add `UpdateOption<T>` enum (`Set` / `Clear` / `Unchanged`) to `archelon-core::ops` to express three-way update semantics for optional fields
- Change `EntryFields.parent` from `Option<EntryRef>` to `UpdateOption<EntryRef>`, so parent can be explicitly cleared as well as set
- Add `--no-parent` flag to `entry set` (conflicts with `--parent`) that sets `UpdateOption::Clear`, enabling root-drop reparenting from the VSCode tree view

## Motivation

The drag-and-drop reparenting feature (#52) needs a way to unset the parent when an entry is dropped onto the tree root. Previously the CLI had no mechanism to clear `parent_id`.

## Test plan

- [x] `archelon entry set <path> --no-parent` clears `parent_id` in the frontmatter
- [x] `--no-parent` and `--parent` together are rejected with a conflict error
- [x] `archelon entry set <path>` with no flags still errors "nothing to update"
- [x] `archelon entry new --parent @<id>` still sets parent correctly
- [ ] MCP `entry_create` / `entry_update` still work with and without a parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)