### PR TITLE
feat: rename `entry set` to `entry modify`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `task.started_at` timestamp field: auto-set when task status transitions to `in_progress`; supports manual override via `--task-started-at DATETIME` in `entry new` / `entry set`
+- `task.started_at` timestamp field: auto-set when task status transitions to `in_progress`; supports manual override via `--task-started-at DATETIME` in `entry new` / `entry modify`
 - `--task-started` filter for `entry list` (CLI and MCP): matches in-progress tasks (with optional `--period` overlap check)
 - Preserve unknown frontmatter fields across round-trips — unknown YAML keys in `Frontmatter`, `TaskMeta`, and `EventMeta` are now retained on read/write, preventing data loss when entries were created by a newer version of archelon
 

--- a/archelon-core/src/entry.rs
+++ b/archelon-core/src/entry.rs
@@ -59,12 +59,12 @@ pub struct TaskMeta {
     pub status: String,
 
     /// Timestamp when the task was started (status → in_progress).
-    /// Set automatically by `entry set`; can be overridden manually.
+    /// Set automatically by `entry modify`; can be overridden manually.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "naive_datetime_serde::opt")]
     pub started_at: Option<NaiveDateTime>,
 
     /// Timestamp when the task was closed (status → done/cancelled/archived).
-    /// Set automatically by `entry set`; can be overridden manually.
+    /// Set automatically by `entry modify`; can be overridden manually.
     #[serde(default, skip_serializing_if = "Option::is_none", with = "naive_datetime_serde::opt")]
     pub closed_at: Option<NaiveDateTime>,
 

--- a/archelon-vscode/src/cli.ts
+++ b/archelon-vscode/src/cli.ts
@@ -79,11 +79,11 @@ export async function removeEntry(entry: string, cwd: string): Promise<void> {
 }
 
 /**
- * Run `archelon entry set <entryPath> --parent @<parentId>`.
+ * Run `archelon entry modify <entryPath> --parent @<parentId>`.
  * Throws on non-zero exit.
  */
 export async function setEntryParent(entryPath: string, parentId: string, cwd: string): Promise<void> {
-    await execFileAsync(bin(), ['entry', 'set', entryPath, '--parent', `@${parentId}`], { cwd });
+    await execFileAsync(bin(), ['entry', 'modify', entryPath, '--parent', `@${parentId}`], { cwd });
 }
 
 export interface EntryRecord {

--- a/archelon/README.md
+++ b/archelon/README.md
@@ -142,10 +142,10 @@ Opens the entry in `$EDITOR`.
 #### Update frontmatter fields
 
 ```bash
-archelon entry set <file-or-id> --title "New title"
-archelon entry set <file-or-id> --tags work,backend
-archelon entry set <file-or-id> --tags          # clear all tags
-archelon entry set <file-or-id> --task-status done
+archelon entry modify <file-or-id> --title "New title"
+archelon entry modify <file-or-id> --tags work,backend
+archelon entry modify <file-or-id> --tags          # clear all tags
+archelon entry modify <file-or-id> --task-status done
 ```
 
 When `--task-status` is set to `done`, `cancelled`, or `archived`, `closed_at` is set automatically.

--- a/archelon/src/commands/entry.rs
+++ b/archelon/src/commands/entry.rs
@@ -145,7 +145,7 @@ pub enum EntryCommand {
         new: bool,
     },
     /// Update frontmatter fields without opening an editor
-    Set {
+    Modify {
         /// Path to the entry file, or an ID / ID prefix
         entry: String,
 
@@ -194,7 +194,7 @@ pub enum EntryCommand {
     },
 }
 
-/// Frontmatter fields shared between `entry new` and `entry set` (clap-aware).
+/// Frontmatter fields shared between `entry new` and `entry modify` (clap-aware).
 ///
 /// After parsing this is converted into [`archelon_core::ops::EntryFields`]
 /// and passed to the core operation functions.
@@ -204,7 +204,7 @@ pub struct EntryFields {
     #[arg(long, short)]
     pub title: Option<String>,
 
-    /// Body content (Markdown). For `entry set`, replaces the existing body.
+    /// Body content (Markdown). For `entry modify`, replaces the existing body.
     #[arg(long, short)]
     pub body: Option<String>,
 
@@ -293,7 +293,7 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
                 bail!("specify an entry or use --new to create one")
             }
         }
-        EntryCommand::Set { entry, fields, no_parent } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields, no_parent),
+        EntryCommand::Modify { entry, fields, no_parent } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields, no_parent),
         EntryCommand::Check { entry } => check(journal_dir, &entry),
         EntryCommand::Fix { entry, touch } => fix(journal_dir, &entry, touch),
         EntryCommand::Path { entry, new, parent } => entry_path(journal_dir, entry.as_deref(), new, parent.as_deref()),
@@ -587,7 +587,7 @@ fn edit_new(journal_dir: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-// ── set ───────────────────────────────────────────────────────────────────────
+// ── modify ────────────────────────────────────────────────────────────────────
 
 fn set(journal_dir: Option<&Path>, path: &Path, fields: EntryFields, no_parent: bool) -> Result<()> {
     if fields.title.is_none()

--- a/archelon/src/commands/mcp.rs
+++ b/archelon/src/commands/mcp.rs
@@ -148,7 +148,7 @@ struct EntryNewParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-struct EntrySetParams {
+struct EntryModifyParams {
     /// File path to the entry, or an ID / ID prefix
     entry: String,
     /// New title
@@ -485,7 +485,7 @@ impl ArchelonServer {
     }
 
     #[tool(description = "Update frontmatter fields of an existing journal entry")]
-    fn entry_set(&self, Parameters(p): Parameters<EntrySetParams>) -> Result<String, String> {
+    fn entry_modify(&self, Parameters(p): Parameters<EntryModifyParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             if p.title.is_none()
                 && p.body.is_none()
@@ -645,7 +645,7 @@ impl ServerHandler for ArchelonServer {
             .with_instructions(
                 "Archelon is a Markdown-based journal/task manager. \
                  Use entry_list to browse entries, entry_show to read one, \
-                 entry_new to create, and entry_set to update metadata."
+                 entry_new to create, and entry_modify to update metadata."
                     .to_owned(),
             )
     }


### PR DESCRIPTION
## Summary

- Rename the `entry set` subcommand to `entry modify` across CLI, MCP server, VSCode extension, and documentation
- `entry modify` better conveys the operation (updating specific frontmatter fields) and avoids the misleading `key value` setter pattern implied by `set`
- Mirrors the naming convention used by tools like `nmcli`

## Changes

- **CLI** ([`entry.rs`](archelon/src/commands/entry.rs)): `EntryCommand::Set` → `EntryCommand::Modify`
- **MCP server** ([`mcp.rs`](archelon/src/commands/mcp.rs)): `EntrySetParams` → `EntryModifyParams`, `entry_set()` → `entry_modify()`
- **VSCode extension** ([`cli.ts`](archelon-vscode/src/cli.ts)): command args `entry set` → `entry modify`
- **Docs**: `README.md`, `CHANGELOG.md`, and inline code comments updated

## Test plan

- [x] `archelon entry modify <id> --title "..."` updates the entry title
- [x] `archelon entry modify <id> --task-status done` sets `closed_at` automatically
- [x] `archelon entry modify <id> --no-parent` removes the parent relationship
- [ ] MCP tool `entry_modify` works correctly via MCP client
- [x] VSCode drag-and-drop reparenting still works (calls `entry modify` internally)
- [x] `archelon entry set` now shows an error (unknown subcommand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)