### PR TITLE
fix: replace fullwidth space placeholder with fullwidth middle dot

### DIFF
--- a/archelon-core/src/emoji.rs
+++ b/archelon-core/src/emoji.rs
@@ -92,12 +92,12 @@ pub fn entry_emoji(task: Option<&TaskMeta>, event: Option<&EventMeta>) -> &'stat
 
 /// Render symbols into a fixed 2-slot string for terminal output.
 ///
-/// Each missing slot is replaced with a fullwidth space (U+3000 `　`).
+/// Each missing slot is replaced with a fullwidth middle dot (U+30FB `・`).
 /// The result is always exactly 2 visual columns wide.
 pub fn symbols_text(symbols: &[Symbol]) -> String {
     match symbols.len() {
-        0 => "　　".to_owned(),
-        1 => format!("　{}", symbols[0].emoji),
+        0 => "・・".to_owned(),
+        1 => format!("・{}", symbols[0].emoji),
         _ => format!("{}{}", symbols[0].emoji, symbols[1].emoji),
     }
 }

--- a/archelon-vscode/src/entryTreeProvider.ts
+++ b/archelon-vscode/src/entryTreeProvider.ts
@@ -11,7 +11,7 @@ export class EntryItem extends vscode.TreeItem {
         public readonly children: EntryRecord[],
     ) {
         const typeSymbol = record.symbols?.[record.symbols.length - 1]?.emoji ?? '📝';
-        const freshnessSymbol = record.symbols && record.symbols.length > 1 ? record.symbols[0].emoji : '　';
+        const freshnessSymbol = record.symbols && record.symbols.length > 1 ? record.symbols[0].emoji : '・';
         const emojiSlot = `${freshnessSymbol}${typeSymbol}`;
         super(
             `${emojiSlot} ${record.title || '(untitled)'}`,


### PR DESCRIPTION
## Summary

- In `symbols_text`, empty emoji slots were previously filled with a fullwidth space (U+3000 `　`), which was visually indistinguishable from indentation.
- Replaced with fullwidth middle dot (U+30FB `・`), which clearly signals a placeholder without being confused for whitespace.
- Updated the doc comment to reflect the new character.

## Test plan

- [x] Run existing emoji-related tests to confirm no regressions.
- [x] Visually verify that list output shows `・` in empty slots instead of a blank-looking space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)