### PR TITLE
feat: period as positional arg, --all-periods flag, and new period shortcuts

### DIFF
--- a/archelon-core/src/period.rs
+++ b/archelon-core/src/period.rs
@@ -96,6 +96,20 @@ pub fn parse_period(s: &str, week_start: WeekStart) -> Result<Period, String> {
         return Ok(Period::Range(start, end));
     }
 
+    if s == "yesterday" {
+        let d = today - Duration::days(1);
+        let start = d.and_hms_opt(0, 0, 0).unwrap();
+        let end = d.and_hms_opt(23, 59, 59).unwrap();
+        return Ok(Period::Range(start, end));
+    }
+
+    if s == "tomorrow" {
+        let d = today + Duration::days(1);
+        let start = d.and_hms_opt(0, 0, 0).unwrap();
+        let end = d.and_hms_opt(23, 59, 59).unwrap();
+        return Ok(Period::Range(start, end));
+    }
+
     if s == "this_week" {
         let days_back = match week_start {
             WeekStart::Monday => today.weekday().num_days_from_monday(),
@@ -105,6 +119,32 @@ pub fn parse_period(s: &str, week_start: WeekStart) -> Result<Period, String> {
         let week_end_date = week_start_date + Duration::days(6);
         let start = week_start_date.and_hms_opt(0, 0, 0).unwrap();
         let end = week_end_date.and_hms_opt(23, 59, 59).unwrap();
+        return Ok(Period::Range(start, end));
+    }
+
+    if s == "last_week" {
+        let d = today - Duration::days(7);
+        let days_back = match week_start {
+            WeekStart::Monday => d.weekday().num_days_from_monday(),
+            WeekStart::Sunday => d.weekday().num_days_from_sunday(),
+        };
+        let start_date = d - Duration::days(days_back as i64);
+        let end_date = start_date + Duration::days(6);
+        let start = start_date.and_hms_opt(0, 0, 0).unwrap();
+        let end = end_date.and_hms_opt(23, 59, 59).unwrap();
+        return Ok(Period::Range(start, end));
+    }
+
+    if s == "next_week" {
+        let d = today + Duration::days(7);
+        let days_back = match week_start {
+            WeekStart::Monday => d.weekday().num_days_from_monday(),
+            WeekStart::Sunday => d.weekday().num_days_from_sunday(),
+        };
+        let start_date = d - Duration::days(days_back as i64);
+        let end_date = start_date + Duration::days(6);
+        let start = start_date.and_hms_opt(0, 0, 0).unwrap();
+        let end = end_date.and_hms_opt(23, 59, 59).unwrap();
         return Ok(Period::Range(start, end));
     }
 
@@ -119,6 +159,33 @@ pub fn parse_period(s: &str, week_start: WeekStart) -> Result<Period, String> {
         let month_end = next_month - Duration::days(1);
         let start = month_start.and_hms_opt(0, 0, 0).unwrap();
         let end = month_end.and_hms_opt(23, 59, 59).unwrap();
+        return Ok(Period::Range(start, end));
+    }
+
+    if s == "last_month" {
+        let (year, month) = if today.month() == 1 {
+            (today.year() - 1, 12u32)
+        } else {
+            (today.year(), today.month() - 1)
+        };
+        let start_date = NaiveDate::from_ymd_opt(year, month, 1).unwrap();
+        let end_date = today.with_day(1).unwrap() - Duration::days(1);
+        let start = start_date.and_hms_opt(0, 0, 0).unwrap();
+        let end = end_date.and_hms_opt(23, 59, 59).unwrap();
+        return Ok(Period::Range(start, end));
+    }
+
+    if s == "next_month" {
+        let (year, month) = if today.month() == 12 {
+            (today.year() + 1, 1u32)
+        } else {
+            (today.year(), today.month() + 1)
+        };
+        let start_date = NaiveDate::from_ymd_opt(year, month, 1).unwrap();
+        let (ey, em) = if month == 12 { (year + 1, 1u32) } else { (year, month + 1) };
+        let end_date = NaiveDate::from_ymd_opt(ey, em, 1).unwrap() - Duration::days(1);
+        let start = start_date.and_hms_opt(0, 0, 0).unwrap();
+        let end = end_date.and_hms_opt(23, 59, 59).unwrap();
         return Ok(Period::Range(start, end));
     }
 
@@ -142,7 +209,9 @@ pub fn parse_period(s: &str, week_start: WeekStart) -> Result<Period, String> {
 
     Err(format!(
         "`{s}` is not a valid period — accepted: \
-         none | today | this_week | this_month | \
+         none | today | yesterday | tomorrow | \
+         this_week | last_week | next_week | \
+         this_month | last_month | next_month | \
          YYYY-MM-DD | YYYY-MM-DD,YYYY-MM-DD | \
          YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM"
     ))

--- a/archelon-vscode/src/cli.ts
+++ b/archelon-vscode/src/cli.ts
@@ -106,7 +106,7 @@ export async function listEntries(cwd: string, sortBy?: SortField, sortOrder?: S
     const args = ['entry', 'list', '--json', '--active'];
     if (sortBy) { args.push('--sort-by', sortBy); }
     if (sortOrder) { args.push('--sort-order', sortOrder); }
-    if (period) { args.push('--period', period); }
+    if (period) { args.push(period); } else { args.push('--all-periods'); }
     const { stdout } = await execFileAsync(bin(), args, { cwd });
     return JSON.parse(stdout) as EntryRecord[];
 }
@@ -122,7 +122,7 @@ export async function treeEntries(cwd: string, sortBy?: SortField, sortOrder?: S
     const args = ['entry', 'tree', '--json', '--active'];
     if (sortBy) { args.push('--sort-by', sortBy); }
     if (sortOrder) { args.push('--sort-order', sortOrder); }
-    if (period) { args.push('--period', period); }
+    if (period) { args.push(period); } else { args.push('--all-periods'); }
     const { stdout } = await execFileAsync(bin(), args, { cwd });
     return JSON.parse(stdout) as EntryRecord[];
 }

--- a/archelon/src/commands/entry.rs
+++ b/archelon/src/commands/entry.rs
@@ -20,13 +20,19 @@ pub struct EntryFilterArgs {
     /// Time range to filter against. Without field selectors the period is applied to all
     /// timestamp fields simultaneously (OR). Add selectors to restrict matching.
     ///
-    /// PERIOD formats: today | this_week | this_month | none |
-    /// YYYY-MM-DD | YYYY-MM-DD,YYYY-MM-DD | YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM
-    #[arg(long, value_name = "PERIOD")]
+    /// PERIOD: today | yesterday | tomorrow |
+    ///   this_week | last_week | next_week |
+    ///   this_month | last_month | next_month | none |
+    ///   YYYY-MM-DD | YYYY-MM-DD,YYYY-MM-DD | YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM
+    #[arg(value_name = "PERIOD")]
     pub period: Option<String>,
 
+    /// Show all entries regardless of time range (required when PERIOD is omitted)
+    #[arg(long)]
+    pub all_periods: bool,
+
     /// Enable all selectors at once: task_overdue, task_in_progress, event_span,
-    /// created_at, updated_at. With --period this produces a Bullet Journal-style
+    /// created_at, updated_at. With a PERIOD this produces a Bullet Journal-style
     /// daily/weekly/monthly log view. Individual flags can still be added on top.
     #[arg(long)]
     pub active: bool,
@@ -80,6 +86,12 @@ pub struct EntryFilterArgs {
 }
 
 fn build_filter(args: &EntryFilterArgs, week_start: WeekStart) -> Result<EntryFilter> {
+    if args.period.is_none() && !args.all_periods {
+        bail!(
+            "PERIOD is required (e.g. `today`, `this_week`, `2026-03-15`), \
+             or pass `--all-periods` to show all entries"
+        );
+    }
     let parse = |s: &str| parse_period(s, week_start).map_err(anyhow::Error::msg);
     Ok(EntryFilter {
         period: args.period.as_deref().map(parse).transpose()?,


### PR DESCRIPTION
## Summary

- `--period <PERIOD>` → positional argument `[PERIOD]` on `entry list` / `entry tree`
  - Example: `entry list today --active` (Bullet Journal daily log)
- Add `--all-periods` flag; omitting both PERIOD and `--all-periods` now returns an error instead of silently showing all entries
- Extend period keywords: `yesterday`, `tomorrow`, `last_week`, `next_week`, `last_month`, `next_month`
- Update VSCode `cli.ts` to pass period positionally and fall back to `--all-periods` when period is unset

## Motivation

`entry list --active --period today` is the core daily-log command for this Bullet Journal-inspired app. Making `period` positional reduces friction for the most common workflow. The new keywords (`yesterday`, `last_week`, etc.) cover the "page-turning" pattern — viewing prior/upcoming days, weeks, and months — which is natural in a BuJo context but requires explicit date specification in a CLI.

## Breaking changes

- `--period <value>` is removed; use `entry list <value>` (positional) instead
- Omitting a period now errors; add `--all-periods` to restore the previous all-entries behaviour

## Test plan

- [x] `entry list today --active` shows today's entries
- [x] `entry list yesterday --active` shows yesterday's entries
- [x] `entry list last_week --active` shows last week's entries
- [x] `entry list` (no args) returns an error with a helpful message
- [x] `entry list --all-periods` shows all entries
- [x] VSCode sidebar works with default period (`today`) and with period unset (`--all-periods`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)