### PR TITLE
refactor: remove --touch flag from entry fix

### DIFF
--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -797,7 +797,7 @@ pub fn update_entry(path: &Path, conn: &Connection, fields: EntryFields) -> Resu
         }
     }
 
-    fix_entry_mut(&mut entry, true)
+    fix_entry_mut(&mut entry)
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -955,19 +955,14 @@ fn sync_closed_at(entry: &mut Entry) {
     }
 }
 
-/// Core fix logic on an already-loaded entry: sync `closed_at`, optionally update
-/// `updated_at`, write the file, and rename it if the filename no longer matches the
-/// frontmatter.
-///
-/// `touch`: if `true`, refresh `updated_at` to the current time before writing.
+/// Core fix logic on an already-loaded entry: sync `closed_at`, update `updated_at`,
+/// write the file, and rename it if the filename no longer matches the frontmatter.
 ///
 /// Returns `Some(new_path)` if the file was renamed, `None` otherwise.
-fn fix_entry_mut(entry: &mut Entry, touch: bool) -> Result<Option<PathBuf>> {
+fn fix_entry_mut(entry: &mut Entry) -> Result<Option<PathBuf>> {
     sync_started_at(entry);
     sync_closed_at(entry);
-    if touch {
-        entry.frontmatter.updated_at = chrono::Local::now().naive_local();
-    }
+    entry.frontmatter.updated_at = chrono::Local::now().naive_local();
     std::fs::write(&entry.path, render_entry(entry))?;
 
     let expected = entry_filename_from_frontmatter(entry.frontmatter.id, &entry.frontmatter);
@@ -1003,16 +998,14 @@ fn fix_entry_mut(entry: &mut Entry, touch: bool) -> Result<Option<PathBuf>> {
     Ok(Some(new_path))
 }
 
-/// Normalize an entry: sync `closed_at`, rename the file to match its frontmatter
-/// ID and title/slug, and optionally refresh `updated_at`.
-///
-/// `touch`: if `true`, update `updated_at` to the current time.
+/// Normalize an entry: sync `closed_at`, update `updated_at`, and rename the file
+/// to match its frontmatter ID and title/slug.
 ///
 /// Returns `Some(new_path)` if the file was renamed, `None` if it was already correct.
 /// Returns `Err` if the file is not a managed entry.
-pub fn fix_entry(path: &Path, touch: bool) -> Result<Option<PathBuf>> {
+pub fn fix_entry(path: &Path) -> Result<Option<PathBuf>> {
     let mut entry = read_entry(path)?;
-    fix_entry_mut(&mut entry, touch)
+    fix_entry_mut(&mut entry)
 }
 
 // ── remove ────────────────────────────────────────────────────────────────────

--- a/archelon-vscode/src/cli.ts
+++ b/archelon-vscode/src/cli.ts
@@ -26,7 +26,7 @@ function bin(): string {
 }
 
 /**
- * Run `archelon entry fix --touch <filePath>`.
+ * Run `archelon entry fix <filePath>`.
  *
  * Returns the new absolute path if the file was renamed, or null if it stayed in place.
  * Throws on non-zero exit (e.g. not a managed entry, journal not found).
@@ -34,7 +34,7 @@ function bin(): string {
 export async function fixEntry(filePath: string): Promise<string | null> {
     const { stdout } = await execFileAsync(
         bin(),
-        ['entry', 'fix', '--touch', filePath],
+        ['entry', 'fix', filePath],
         { cwd: path.dirname(filePath) }
     );
     // "renamed: <old_filename> → <new_filename>"

--- a/archelon-vscode/src/extension.ts
+++ b/archelon-vscode/src/extension.ts
@@ -294,7 +294,7 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
-    // ── On save: entry fix --touch ────────────────────────────────────────────
+    // ── On save: entry fix ─────────────────────────────────────────────────────
     context.subscriptions.push(
         vscode.workspace.onDidSaveTextDocument(async (doc: vscode.TextDocument) => {
             const cfg = vscode.workspace.getConfiguration('archelon');

--- a/archelon/src/commands/entry.rs
+++ b/archelon/src/commands/entry.rs
@@ -182,14 +182,10 @@ pub enum EntryCommand {
         /// Path to the entry file, or an ID / ID prefix
         entry: String,
     },
-    /// Normalize an entry: sync closed_at, rename to match frontmatter, and optionally refresh updated_at
+    /// Normalize an entry: sync closed_at, update updated_at, and rename to match frontmatter
     Fix {
         /// Path to the entry file, or an ID / ID prefix
         entry: String,
-
-        /// Also update updated_at to the current time
-        #[arg(long)]
-        touch: bool,
     },
     /// Print the absolute path of an entry, or create a new template and print its path.
     /// Intended for editor integrations that need a file path without opening an editor.
@@ -321,7 +317,7 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
         }
         EntryCommand::Modify { entry, fields, no_parent } => set(journal_dir, &resolve_entry(journal_dir, &entry)?, fields, no_parent),
         EntryCommand::Check { entry } => check(journal_dir, &entry),
-        EntryCommand::Fix { entry, touch } => fix(journal_dir, &entry, touch),
+        EntryCommand::Fix { entry } => fix(journal_dir, &entry),
         EntryCommand::Path { entry, new, parent } => entry_path(journal_dir, entry.as_deref(), new, parent.as_deref()),
         EntryCommand::Remove { entry } => remove(journal_dir, &entry),
     }
@@ -577,7 +573,7 @@ fn edit(path: &Path, journal_dir: Option<&Path>) -> Result<()> {
     if !status.success() {
         bail!("editor exited with non-zero status");
     }
-    let final_path = match ops::fix_entry(path, true)? {
+    let final_path = match ops::fix_entry(path)? {
         Some(new_path) => { println!("updated: {}", new_path.display()); new_path }
         None           => { println!("updated: {}", path.display()); path.to_path_buf() }
     };
@@ -603,7 +599,7 @@ fn edit_new(journal_dir: Option<&Path>) -> Result<()> {
         bail!("editor exited with non-zero status");
     }
 
-    let final_path = match ops::fix_entry(&path, true)? {
+    let final_path = match ops::fix_entry(&path)? {
         Some(new_path) => { println!("created: {}", new_path.display()); new_path }
         None           => { println!("created: {}", path.display()); path }
     };
@@ -666,9 +662,9 @@ fn check(journal_dir: Option<&Path>, entry: &str) -> Result<()> {
 
 // ── fix ───────────────────────────────────────────────────────────────────────
 
-fn fix(journal_dir: Option<&Path>, entry: &str, touch: bool) -> Result<()> {
+fn fix(journal_dir: Option<&Path>, entry: &str) -> Result<()> {
     let path = resolve_entry(journal_dir, entry)?;
-    match ops::fix_entry(&path, touch)? {
+    match ops::fix_entry(&path)? {
         Some(new_path) => println!(
             "renamed: {} → {}",
             path.file_name().unwrap_or_default().to_string_lossy(),

--- a/archelon/src/commands/mcp.rs
+++ b/archelon/src/commands/mcp.rs
@@ -190,9 +190,6 @@ struct EntryCheckParams {
 struct EntryFixParams {
     /// File path to the entry, or an ID / ID prefix
     entry: String,
-    /// If true, also update updated_at to the current time
-    #[serde(default)]
-    touch: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -568,13 +565,13 @@ impl ArchelonServer {
         .map_err(|e| e.to_string())
     }
 
-    #[tool(description = "Normalize an entry: sync closed_at, rename the file to match its frontmatter \
-        ID and title/slug, and optionally refresh updated_at (touch=true). \
+    #[tool(description = "Normalize an entry: sync closed_at, update updated_at, and rename the file \
+        to match its frontmatter ID and title/slug. \
         Reports the rename or confirms the filename is already correct.")]
     fn entry_fix(&self, Parameters(p): Parameters<EntryFixParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             let path = self.resolve_entry(&p.entry)?;
-            match ops::fix_entry(&path, p.touch)? {
+            match ops::fix_entry(&path)? {
                 Some(new_path) => Ok(format!(
                     "renamed: {} → {}",
                     path.file_name().unwrap_or_default().to_string_lossy(),


### PR DESCRIPTION
## Summary

- `entry fix` now always updates `updated_at`, making the `--touch` flag redundant and removing it entirely.
- All existing callers (CLI `entry edit`, `entry modify`, VSCode on-save hook) were already passing `touch=true`, so behaviour is unchanged for them.
- The VSCode extension no longer passes `--touch` when invoking `archelon entry fix`.

## Background

The `--touch` flag was originally added to give callers control over whether `updated_at` should be refreshed. In practice, however, `entry fix` is designed to be called after a user has edited a file (e.g. a VSCode on-save hook), so refreshing `updated_at` is always the correct behaviour. There is no meaningful use case for running `entry fix` without updating `updated_at`.

## Test plan

- [x] `archelon entry fix <entry>` updates `updated_at` and renames the file if the title changed
- [x] VSCode on-save hook correctly normalises the entry without errors
- [x] `archelon entry edit` and `archelon entry modify` continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)