### PR TITLE
refactor: rename JSON output keys to flags/match_flags with lowercase values

### DIFF
--- a/archelon-core/src/ops.rs
+++ b/archelon-core/src/ops.rs
@@ -310,13 +310,13 @@ pub enum MatchLabel {
 impl MatchLabel {
     pub fn as_str(self) -> &'static str {
         match self {
-            MatchLabel::TaskOverdue    => "TASK_OVERDUE",
-            MatchLabel::TaskInProgress => "TASK_IN_PROGRESS",
-            MatchLabel::TaskUnstarted  => "TASK_UNSTARTED",
-            MatchLabel::EventSpan      => "EVENT_SPAN",
-            MatchLabel::CreatedAt      => "CREATED",
-            MatchLabel::UpdatedAt      => "UPDATED",
-            MatchLabel::ParentOfMatch  => "PARENT_OF_MATCH",
+            MatchLabel::TaskOverdue    => "task_overdue",
+            MatchLabel::TaskInProgress => "task_in_progress",
+            MatchLabel::TaskUnstarted  => "task_unstarted",
+            MatchLabel::EventSpan      => "event_span",
+            MatchLabel::CreatedAt      => "created",
+            MatchLabel::UpdatedAt      => "updated",
+            MatchLabel::ParentOfMatch  => "parent_of_match",
         }
     }
 }

--- a/archelon/src/commands/entry.rs
+++ b/archelon/src/commands/entry.rs
@@ -455,10 +455,10 @@ fn print_entries(
                     "tags": entry.frontmatter.tags,
                     "task": entry.frontmatter.task,
                     "event": entry.frontmatter.event,
-                    "status_labels": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
+                    "flags": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
                 });
                 if has_filter {
-                    v["match_labels"] = serde_json::json!(
+                    v["match_flags"] = serde_json::json!(
                         labels.iter().map(|l| l.as_str()).collect::<Vec<_>>()
                     );
                 }
@@ -517,11 +517,11 @@ fn print_tree(roots: &[EntryTreeNode], has_filter: bool, json: bool, mode: Displ
                 "tags": entry.frontmatter.tags,
                 "task": entry.frontmatter.task,
                 "event": entry.frontmatter.event,
-                "status_labels": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
+                "flags": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
                 "children": node.children.iter().map(|c| node_to_json(c, has_filter)).collect::<Vec<_>>(),
             });
             if has_filter {
-                v["match_labels"] = serde_json::json!(
+                v["match_flags"] = serde_json::json!(
                     node.labels.iter().map(|l| l.as_str()).collect::<Vec<_>>()
                 );
             }
@@ -533,7 +533,7 @@ fn print_tree(roots: &[EntryTreeNode], has_filter: bool, json: bool, mode: Displ
     }
 
     fn render_node(node: &EntryTreeNode, has_filter: bool, mode: DisplayMode, prefix: &str, is_last: bool) {
-        let _ = has_filter; // match_labels not shown in text output
+        let _ = has_filter; // match_flags not shown in text output
         let connector = if is_last { "└─" } else { "├─" };
         let id = node.entry.id().to_string();
         let syms = archelon_core::labels::entry_symbols(

--- a/archelon/src/commands/mcp.rs
+++ b/archelon/src/commands/mcp.rs
@@ -340,10 +340,10 @@ impl ArchelonServer {
                         "tags": entry.frontmatter.tags,
                         "task": entry.frontmatter.task,
                         "event": entry.frontmatter.event,
-                        "status_labels": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
+                        "flags": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
                     });
                     if has_filter {
-                        v["match_labels"] = serde_json::json!(
+                        v["match_flags"] = serde_json::json!(
                             match_labels.iter().map(|l| l.as_str()).collect::<Vec<_>>()
                         );
                     }
@@ -411,11 +411,11 @@ impl ArchelonServer {
                     "tags": entry.frontmatter.tags,
                     "task": entry.frontmatter.task,
                     "event": entry.frontmatter.event,
-                    "status_labels": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
+                    "flags": syms.iter().map(|s| s.label).collect::<Vec<_>>(),
                     "children": node.children.iter().map(|c| node_to_json(c, has_filter)).collect::<Vec<_>>(),
                 });
                 if has_filter {
-                    v["match_labels"] = serde_json::json!(
+                    v["match_flags"] = serde_json::json!(
                         node.labels.iter().map(|l| l.as_str()).collect::<Vec<_>>()
                     );
                 }


### PR DESCRIPTION
## Summary

- Rename `status_labels` → `flags` in JSON output of `entry list` and `entry tree`
- Rename `match_labels` → `match_flags` in JSON output when a filter is active
- Convert `MatchLabel::as_str()` return values from `UPPER_SNAKE_CASE` to `lower_snake_case` (e.g. `"TASK_OVERDUE"` → `"task_overdue"`)

`flags` more clearly distinguishes system-computed state indicators from user-defined `tags`. `lower_snake_case` is consistent with the rest of the JSON schema.

## Test plan

- [x] `archelon entry list --json` — output contains `flags` field (not `status_labels`)
- [x] `archelon entry list --json <filter>` — output contains `match_flags` field with lowercase values (e.g. `"task_overdue"`, `"event_span"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)