### PR TITLE
feat(vscode): fix tree icons and expand period filter menu

### DIFF
--- a/archelon-vscode/src/cli.ts
+++ b/archelon-vscode/src/cli.ts
@@ -94,7 +94,7 @@ export interface EntryRecord {
     updated_at: string;
     task?: { status: string; due?: string; closed_at?: string } | null;
     event?: { start: string; end: string } | null;
-    status_labels?: string[];
+    flags?: string[];
     children?: EntryRecord[];
 }
 

--- a/archelon-vscode/src/entryTreeProvider.ts
+++ b/archelon-vscode/src/entryTreeProvider.ts
@@ -29,7 +29,7 @@ export class EntryItem extends vscode.TreeItem {
                 : vscode.TreeItemCollapsibleState.None,
         );
 
-        const typeLabel = record.status_labels?.[record.status_labels.length - 1] ?? 'note';
+        const typeLabel = record.flags?.[record.flags.length - 1] ?? 'note';
         this.iconPath = new vscode.ThemeIcon(typeIconId(typeLabel));
 
         this.command = {
@@ -53,8 +53,8 @@ export class EntryItem extends vscode.TreeItem {
             md.appendMarkdown(`**Tags:** ${record.tags.map(t => `\`#${t}\``).join(' ')}  \n`);
         }
         md.appendMarkdown(`**Updated:** ${record.updated_at.slice(0, 19).replace('T', ' ')}  \n`);
-        if (record.status_labels && record.status_labels.length > 1) {
-            md.appendMarkdown(`**Freshness:** ${record.status_labels[0]}  \n`);
+        if (record.flags && record.flags.length > 1) {
+            md.appendMarkdown(`**Freshness:** ${record.flags[0]}  \n`);
         }
         if (record.task) {
             let taskLine = `**Task:** ${record.task.status}`;

--- a/archelon-vscode/src/extension.ts
+++ b/archelon-vscode/src/extension.ts
@@ -201,10 +201,16 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.commands.registerCommand('archelon.setPeriod', async () => {
             const presets: { label: string; period: string | undefined }[] = [
-                { label: '$(circle-slash) All (clear period filter)', period: undefined },
-                { label: '$(calendar) Today',      period: 'today' },
-                { label: '$(calendar) This week',  period: 'this_week' },
-                { label: '$(calendar) This month', period: 'this_month' },
+                { label: '$(list-unordered) All',        period: undefined },
+                { label: '$(calendar) Yesterday',        period: 'yesterday' },
+                { label: '$(calendar) Today',            period: 'today' },
+                { label: '$(calendar) Tomorrow',         period: 'tomorrow' },
+                { label: '$(calendar) Last week',         period: 'last_week' },
+                { label: '$(calendar) This week',        period: 'this_week' },
+                { label: '$(calendar) Next week',        period: 'next_week' },
+                { label: '$(calendar) This month',       period: 'this_month' },
+                { label: '$(calendar) Last month',       period: 'last_month' },
+                { label: '$(calendar) Next month',       period: 'next_month' },
                 { label: '$(edit) Custom date / range…', period: '__custom__' },
             ];
             const picked = await vscode.window.showQuickPick(presets, {


### PR DESCRIPTION
## Summary

- **Fix tree view icons**: All entries were showing as note icons because `EntryRecord.status_labels` was not updated to `flags` after the CLI JSON output rename (b9c97fb)
- **Expand period filter menu**: Added `yesterday`, `tomorrow`, `last_week`, `next_week`, `last_month`, `next_month`, and `all` to the calendar button quick pick; removed the `clear period filter` label

## Changes

- `cli.ts`: Rename `EntryRecord.status_labels` → `flags`
- `entryTreeProvider.ts`: Update `record.status_labels` references → `record.flags`
- `extension.ts`: Update period filter preset list

## Test plan

- [x] Tree view entries display correct icons based on type (event/done/cancelled/in_progress/archived/open)
- [x] Calendar button menu shows yesterday / tomorrow / last_week / next_week / last_month / next_month / all
- [x] Selecting each period correctly filters the entry list

🤖 Generated with [Claude Code](https://claude.com/claude-code)