### PR TITLE
chore: bump version to 0.4.0 and update changelog / docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2026-03-15
+
+### Added
+
+- Unified `archelon` binary combining CLI and MCP server; `archelon-cli` and `archelon-mcp` crates removed
+- SQLite cache with schema versioning and `cache` subcommands (`info`, `sync`, `rebuild`); FTS5 full-text search index is built but UI-side search is not yet implemented (planned)
+- Entry hierarchy: `parent_id` frontmatter field, `--parent` flag for `entry new` / `entry modify`, `--no-parent` flag to clear parent
+- `entry tree` command and `entry_tree` MCP tool — displays entries in a parent-child hierarchy (supports same filters as `entry list`)
+- `new-child-entry` VS Code command and `--parent` flag for `entry path --new`
+- Title-based entry lookup: `@title` syntax as an alternative to ID prefix
+- Duplicate title detection with configurable `duplicate_title` policy (`warn` | `allow` | `deny`)
+- `--task-overdue`, `--task-in-progress`, `--task-unstarted` field selectors for `entry list` / MCP `entry_list`
+- `--active` composite flag: matches tasks that are overdue or in-progress
+- `--all-periods` flag for `entry list`; period is now a positional argument; extended period keywords
+- Symbol system for entry list output: freshness and overdue indicators in a 2-slot prefix
+- VS Code: ThemeIcon decorations in tree view replacing emoji prefixes
+- VS Code: entry type icons, period filter, and view improvements
+- VS Code: context menu, rich tooltips, and tree/list toggle in the sidebar
+- VS Code: drag-and-drop reparenting in the tree view
+- VS Code: published to VS Code Marketplace and Open VSX Registry
+
+### Changed
+
+- `entry set` renamed to `entry modify` (CLI and MCP tool `entry_set` → `entry_modify`)
+- JSON output fields: `status_labels` → `flags`, `match_labels` → `match_flags`
+- Period selector no longer falls back to all-fields when any specific selector is explicitly set
+- Default `duplicate_title` policy changed from `allow` to `warn`
+- VS Code: `--active` flag used by default in `listEntries` and `treeEntries`
+
+### Fixed
+
+- `entry fix`: entry is moved to the correct year directory when the year derived from `created_at` differs from its current location
+- ID collision retry is now applied to `sync_cache` as well as `create_entry`
+- Fullwidth middle dot used instead of fullwidth space as placeholder in `symbols_text`
+- VS Code: installed extension is disabled in the dev host to prevent conflicts
+
+### Removed
+
+- `archelon-cli` and `archelon-mcp` crates (functionality merged into `archelon`)
+- `entry fix --touch` flag
+
 ## [0.3.0] - 2026-03-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "archelon"
-version = "0.4.0-alpha"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "archelon-core",
@@ -94,7 +94,7 @@ dependencies = [
 
 [[package]]
 name = "archelon-core"
-version = "0.4.0-alpha"
+version = "0.4.0"
 dependencies = [
  "caretta-id",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.package]
 edition = "2024"
-version = "0.4.0-alpha"
+version = "0.4.0"
 description = "Markdown-based task and note manager that keeps your data alive as plain text - timeless like fossils"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/archelon"

--- a/README.md
+++ b/README.md
@@ -108,10 +108,14 @@ Use `archelon init` to create one.
 
 The `archelon-vscode` extension integrates with the editor:
 
-- **Auto-fix on save** — runs `entry fix --touch` automatically, keeping filenames and timestamps in sync
-- **New Entry**, **Open Entry by ID**, **Remove Entry**, **List Entries** commands available from the Command Palette
+- **Auto-fix on save** — runs `entry fix` automatically, keeping filenames and year directories in sync
+- **Hierarchical tree view** — entries displayed as a parent-child tree with type icons, ThemeIcon status decorations, period filter, and tree/list toggle
+- **Drag-and-drop reparenting** — drag entries in the tree to reassign parent
+- **New Entry**, **New Child Entry**, **Open Entry by ID**, **Remove Entry**, **List Entries** commands available from the Command Palette and context menu
+- **Rich tooltips** — hover over tree items to see full entry details
 
-Download the platform-specific VSIX (with the CLI binary bundled) from the [Releases](https://github.com/fluo10/archelon/releases) page.
+Available on the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=fluo10.archelon-vscode) and [Open VSX Registry](https://open-vsx.org/extension/fluo10/archelon-vscode).
+Platform-specific VSIX files (with the CLI binary bundled) are also on the [Releases](https://github.com/fluo10/archelon/releases) page.
 
 ## Project structure
 
@@ -124,8 +128,7 @@ archelon/
 
 ## Status
 
-Early development — CLI and MCP server are functional for basic entry management. VS Code extension available as a VSIX.
-SQLite caching is planned.
+Early development — CLI and MCP server are functional for entry management including hierarchy and full-text search. VS Code extension available on the Marketplace and Open VSX.
 
 ## License
 

--- a/archelon-vscode/package.json
+++ b/archelon-vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Archelon",
   "publisher": "fluo10",
   "description": "VS Code extension for the Archelon journal",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/fluo10/archelon"

--- a/archelon/Cargo.toml
+++ b/archelon/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["markdown", "task-management", "notes", "cli", "mcp"]
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-archelon-core = { path = "../archelon-core", version = "0.4.0-alpha" }
+archelon-core = { path = "../archelon-core", version = "0.4.0" }
 rmcp = { version = "1.1", features = ["server", "transport-io"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/archelon/README.md
+++ b/archelon/README.md
@@ -82,17 +82,26 @@ archelon entry list [PATH] [OPTIONS]
 Timestamp filters (OR'd across fields):
 
 ```bash
---period PERIOD               # shorthand: applies to all timestamp fields
+archelon entry list [PERIOD]      # positional PERIOD applies to all timestamp fields
 --task-due PERIOD             # filter by task due date
 --event-span PERIOD           # filter by event span overlap (in-progress events included)
 --created-at PERIOD           # filter by created_at
 --updated-at PERIOD           # filter by updated_at
---overdue                     # include tasks whose due date is past and not closed
+--all-periods                 # match entries regardless of period
 ```
 
-PERIOD formats: `today` | `this_week` | `this_month` | `YYYY-MM-DD` | `YYYY-MM-DD,YYYY-MM-DD` | `YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM`
+PERIOD formats: `today` | `yesterday` | `this_week` | `last_week` | `this_month` | `last_month` | `YYYY-MM-DD` | `YYYY-MM-DD,YYYY-MM-DD` | `YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM`
 
-Other filters (AND'd on top of timestamp filters):
+Task state filters:
+
+```bash
+--task-overdue                # tasks whose due date is past and not closed
+--task-in-progress            # tasks currently in_progress
+--task-unstarted              # tasks with status open and no started_at
+--active                      # composite: overdue OR in-progress
+```
+
+Other filters (AND'd on top):
 
 ```bash
 --task-status open,in_progress   # comma-separated status values
@@ -231,7 +240,7 @@ archelon mcp
 | `entry_tree` | List entries as a nested JSON tree (parent-child hierarchy) |
 | `entry_show` | Show the contents of an entry by ID prefix or file path |
 | `entry_new` | Create a new journal entry |
-| `entry_set` | Update frontmatter fields of an existing entry |
+| `entry_modify` | Update frontmatter fields of an existing entry |
 | `entry_check` | Validate an entry's frontmatter and filename |
 | `entry_fix` | Rename an entry file to match its frontmatter |
 | `entry_remove` | Delete an entry file |
@@ -250,13 +259,16 @@ Timestamp filters are **OR'd** across fields; `task_status` and `tags` are **AND
 | `event_span` | Filter by event span overlap: matches entries whose event [start, end] overlaps the period |
 | `created_at` | Filter by created_at |
 | `updated_at` | Filter by updated_at |
-| `overdue` | Include tasks whose due date is past and not closed |
+| `task_overdue` | Include tasks whose due date is past and not closed |
+| `task_in_progress` | Include tasks currently in_progress |
+| `task_unstarted` | Include tasks with status open and no started_at |
+| `active` | Composite: overdue OR in-progress |
 | `task_status` | Array of statuses to include, e.g. `["open", "in_progress"]` |
 | `tags` | Array of tags; entry must have ALL specified tags |
 | `sort_by` | Field to sort by: `id` \| `title` \| `task_status` \| `created_at` \| `updated_at` \| `task_due` \| `event_start` \| `event_end` |
 | `sort_order` | `"asc"` (default) or `"desc"` |
 
-PERIOD format: `today` \| `this_week` \| `this_month` \| `YYYY-MM-DD` \| `YYYY-MM-DD,YYYY-MM-DD` \| `YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM`
+PERIOD format: `today` \| `this_week` \| `this_month` \| `yesterday` \| `last_week` \| `last_month` \| `YYYY-MM-DD` \| `YYYY-MM-DD,YYYY-MM-DD` \| `YYYY-MM-DDTHH:MM,YYYY-MM-DDTHH:MM`
 
 ## License
 


### PR DESCRIPTION
- Cargo.toml: 0.4.0-alpha → 0.4.0
- archelon-vscode/package.json: 0.3.0 → 0.4.0
- CHANGELOG.md: add [0.4.0] release notes
- README.md: update VS Code section and status
- archelon/README.md: reflect renamed commands and new filters