### PR TITLE
Release CLI 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7399,7 +7399,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7416,7 +7416,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "grain-id",
@@ -7448,9 +7448,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0cee02b4b61d6d280051361f010264442ac6576bf8e5f35bde9d0f5aafd4cf"
+checksum = "e82f1e21211d82badee2194ed69145e020a45af973a8f86e73f9b7af7c600a25"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -7468,9 +7468,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d958dbced3e0f5d04acf041cf55d7a9d00e03cc4ace9c5d74cc7c83e6486f3"
+checksum = "0633ecb2091bde4afd8e33c0b5caeb0e52653e65f1b3e3762b3de49f2a593975"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -7478,9 +7478,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d84f06f3230cfb790c0ae1fe32b884ea6bced92b7136457fbf1cce68bd9ab"
+checksum = "e1c8e03c0c6cf85c1ad43f1bd6f2563235359ef21d3a8ed8c9d7c30ff57f8c11"
 dependencies = [
  "dirs 5.0.1",
  "indexmap 2.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Markdown-based task and note manager that keeps your data alive a
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-journal"
 edition = "2024"
+version = "0.10.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/sapphire-journal-core/Cargo.toml
+++ b/sapphire-journal-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sapphire-journal-core"
 edition.workspace = true
-version = "0.9.0"
+version.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -26,5 +26,5 @@ serde_json.workspace = true
 schemars.workspace = true
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-sapphire-workspace = { version = "0.5.0", default-features = false }
+sapphire-workspace = { version = "0.5.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde", "rusqlite", "schemars"] }

--- a/sapphire-journal-dioxus/Cargo.toml
+++ b/sapphire-journal-dioxus/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 repository.workspace = true
 
 [dependencies]
-sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.9.0" }
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.10.0" }
 dioxus = { version = "0.7.1", features = [] }
 git2 = { version = "0.20", default-features = false }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/sapphire-journal/CHANGELOG.md
+++ b/sapphire-journal/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 All notable changes to `sapphire-journal` and `sapphire-journal-core` are documented here.
 
-## [0.9.0] - 2026-04-06
+## [0.10.0] - 2026-04-10
+
+### Changed
+
+- Bumped `sapphire-workspace`, `sapphire-sync`, and `sapphire-retrieve` to 0.5.0 (now developed in a standalone repository).
+- Cache directory layout reorganized via the new `AppContext`: cross-platform cache base resolution and `app_name` folded into the cache path.
+- Embedding model cache directory is now injectable through config.
+
+### Fixed
+
+- `sajo mcp`: corrected config path lookup from `cache.embedding` to `cache.retrieve.embedding`.
+
 
 ### Added
 

--- a/sapphire-journal/Cargo.toml
+++ b/sapphire-journal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sapphire-journal"
 edition.workspace = true
-version = "0.9.0"
+version.workspace = true
 description.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -20,7 +20,7 @@ fastembed-embed = ["sapphire-journal-core/fastembed-embed"]
 
 [dependencies]
 clap.workspace = true
-sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.9.0", default-features = false }
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.10.0", default-features = false }
 rmcp.workspace = true
 tokio = { workspace = true, features = ["full"] }
 serde.workspace = true


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.10.0 (config format change warrants a minor bump over 0.9.x)
- Update `sapphire-workspace`, `sapphire-sync`, `sapphire-retrieve` to 0.5.0 (now in a standalone repository)
- Reorganize cache directory layout via the new `AppContext` (cross-platform cache base, `app_name` folded into the path)
- Make embedding model cache directory injectable through config
- Fix `sajo mcp` config path lookup: `cache.embedding` → `cache.retrieve.embedding`

## Test plan
- [x] `cargo publish --dry-run` passes
- [ ] CI green
- [ ] Release workflow publishes to crates.io on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)