### PR TITLE
chore: release sapphire-journal-vscode 0.10.0

### DIFF
--- a/sapphire-journal-vscode/CHANGELOG.md
+++ b/sapphire-journal-vscode/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to `sapphire-journal-vscode` are documented here.
 
+## [0.10.0] - 2026-04-10
+
+### Added
+
+- Hide the activity bar icon when the current workspace is not a Sapphire Journal
+
+### Changed
+
+- Bundled `sapphire-journal` CLI updated to 0.10.0
+- Consolidated VSCode configuration from subdirectory to workspace root
+
+### Fixed
+
+- Bundle runtime dependencies and build the CLI inline in the release workflow so the packaged VSIX runs without missing modules
+
 ## [0.8.0] - 2026-03-30
 
 ### Added

--- a/sapphire-journal-vscode/package.json
+++ b/sapphire-journal-vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Sapphire Journal",
   "publisher": "fluo10",
   "description": "VS Code extension for the Sapphire Journal",
-  "version": "0.8.0",
+  "version": "0.10.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/fluo10/sapphire-journal"


### PR DESCRIPTION
## Summary
- Bump `sapphire-journal-vscode` to 0.10.0
- Update CHANGELOG with changes since 0.8.0 (bundled CLI → 0.10.0, workspace config consolidation, activity bar icon visibility, release bundling fix)

## Test plan
- [ ] CI builds the VSIX successfully
- [ ] Installed VSIX activates only on journal workspaces
- [ ] Bundled `sajo` binary runs without missing modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)