### PR TITLE
feat: integrate sapphire-workspace git-sync for periodic synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe 0.1.6",
+ "openssl-sys",
  "url",
 ]
 
@@ -5081,7 +5083,9 @@ checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -5127,6 +5131,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -5628,7 +5646,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "openssl-sys",
  "schannel",
  "security-framework",
@@ -6050,6 +6068,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -7338,7 +7362,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -7472,6 +7496,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0633ecb2091bde4afd8e33c0b5caeb0e52653e65f1b3e3762b3de49f2a593975"
 dependencies = [
+ "git2",
  "serde",
  "thiserror 2.0.18",
 ]

--- a/sapphire-journal-core/Cargo.toml
+++ b/sapphire-journal-core/Cargo.toml
@@ -9,10 +9,11 @@ categories = ["text-processing", "filesystem", "data-structures"]
 keywords = ["markdown", "task-management", "notes", "frontmatter", "plain-text"]
 
 [features]
-default = ["sqlite-store", "lancedb-store", "fastembed-embed"]
+default = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync"]
 sqlite-store    = ["sapphire-workspace/sqlite-store"]
 lancedb-store   = ["sapphire-workspace/lancedb-store"]
 fastembed-embed = ["sapphire-workspace/fastembed-embed"]
+git-sync        = ["sapphire-workspace/git-sync"]
 
 [dependencies]
 serde.workspace = true

--- a/sapphire-journal-core/src/error.rs
+++ b/sapphire-journal-core/src/error.rs
@@ -44,6 +44,9 @@ pub enum Error {
     #[error("embedding error: {0}")]
     Embed(String),
 
+    #[error("sync error: {0}")]
+    Sync(String),
+
     /// The cache DB was created by a newer version of sapphire-journal.
     /// The user must either update sapphire-journal or recreate the cache.
     #[error(

--- a/sapphire-journal-core/src/journal_state.rs
+++ b/sapphire-journal-core/src/journal_state.rs
@@ -14,8 +14,10 @@
 //! The embedder is expensive to initialise (ONNX model load), so it is cached
 //! in a [`tokio::sync::OnceCell`] field.
 
+use std::path::Path;
+
 use tokio::sync::OnceCell;
-use sapphire_workspace::{Embedder, RetrieveDb};
+use sapphire_workspace::{Embedder, RetrieveDb, SyncBackend};
 
 use crate::{
     cache,
@@ -32,19 +34,32 @@ pub struct JournalState {
     /// Always-present retrieve database (FTS + optional vector backend).
     retrieve_db: RetrieveDb,
     embedder: OnceCell<Option<Box<dyn Embedder + Send + Sync>>>,
+    /// Optional sync backend (e.g. git) for staging file changes and running
+    /// periodic sync cycles.
+    sync_backend: Option<Box<dyn SyncBackend + Send + Sync>>,
 }
 
 impl JournalState {
     /// Open the cache for `journal`, creating it if it does not yet exist.
+    ///
+    /// When the `git-sync` feature is enabled, automatically attaches a
+    /// [`sapphire_workspace::GitSync`] backend if the journal root is inside
+    /// a git repository.
     pub fn open(journal: Journal) -> Result<Self> {
         let conn = cache::open_cache(&journal)?;
         drop(conn);
         let retrieve_db = RetrieveDb::open(&journal.retrieve_db_path()?)?;
-        Ok(Self {
+        let mut state = Self {
             journal,
             retrieve_db,
             embedder: OnceCell::new(),
-        })
+            sync_backend: None,
+        };
+        #[cfg(feature = "git-sync")]
+        if let Ok(git) = sapphire_workspace::GitSync::open(&state.journal.root) {
+            state.sync_backend = Some(Box::new(git));
+        }
+        Ok(state)
     }
 
     /// Drop and recreate both the cache and the retrieve database from scratch.
@@ -57,11 +72,17 @@ impl JournalState {
             use sapphire_workspace::lancedb_store;
             let _ = std::fs::remove_dir_all(lancedb_store::data_dir(&journal.cache_dir()?));
         }
-        Ok(Self {
+        let mut state = Self {
             journal,
             retrieve_db,
             embedder: OnceCell::new(),
-        })
+            sync_backend: None,
+        };
+        #[cfg(feature = "git-sync")]
+        if let Ok(git) = sapphire_workspace::GitSync::open(&state.journal.root) {
+            state.sync_backend = Some(Box::new(git));
+        }
+        Ok(state)
     }
 
     /// Open a fresh SQLite connection to the cache database.
@@ -241,5 +262,45 @@ impl JournalState {
 
         let Some(embedder) = self.embedder() else { return Ok(0) };
         Ok(self.retrieve_db.embed_pending(embedder, on_progress)?)
+    }
+
+    // ── sync backend ─────────────────────────────────────────────────────────
+
+    /// Returns `true` if a sync backend (e.g. git) is attached.
+    pub fn has_sync_backend(&self) -> bool {
+        self.sync_backend.is_some()
+    }
+
+    /// Notify the sync backend that `path` was created or modified so it can
+    /// be staged for the next sync cycle (e.g. `git add`).
+    ///
+    /// No-op when no sync backend is configured.
+    pub fn on_file_updated(&self, path: &Path) -> Result<()> {
+        if let Some(sync) = &self.sync_backend {
+            sync.add_file(path).map_err(|e| crate::error::Error::Sync(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Notify the sync backend that `path` was deleted so it can be unstaged
+    /// (e.g. `git rm --cached`).
+    ///
+    /// No-op when no sync backend is configured.
+    pub fn on_file_deleted(&self, path: &Path) -> Result<()> {
+        if let Some(sync) = &self.sync_backend {
+            sync.remove_file(path).map_err(|e| crate::error::Error::Sync(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Run a full sync cycle: commit staged changes, fetch+merge from remote,
+    /// then push.
+    ///
+    /// No-op when no sync backend is configured.
+    pub fn git_sync(&self) -> Result<()> {
+        if let Some(sync) = &self.sync_backend {
+            sync.sync().map_err(|e| crate::error::Error::Sync(e.to_string()))?;
+        }
+        Ok(())
     }
 }

--- a/sapphire-journal-core/src/lib.rs
+++ b/sapphire-journal-core/src/lib.rs
@@ -33,6 +33,9 @@ pub mod user_config;
 
 pub use journal_state::JournalState;
 pub use sapphire_workspace::RetrieveDb;
+pub use sapphire_workspace::SyncBackend;
+#[cfg(feature = "git-sync")]
+pub use sapphire_workspace::GitSync;
 
 /// Shared application context for sapphire-journal.
 ///

--- a/sapphire-journal-core/src/user_config.rs
+++ b/sapphire-journal-core/src/user_config.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
-pub use sapphire_workspace::{EmbeddingConfig, RetrieveConfig, VectorDb};
+pub use sapphire_workspace::{EmbeddingConfig, RetrieveConfig, SyncConfig, VectorDb};
 
 /// Contents of `$XDG_CONFIG_HOME/sapphire-journal/config.toml`.
 ///
@@ -17,6 +17,10 @@ pub use sapphire_workspace::{EmbeddingConfig, RetrieveConfig, VectorDb};
 pub struct UserConfig {
     #[serde(default)]
     pub cache: CacheConfig,
+
+    /// Sync backend configuration (`[sync]` section).
+    #[serde(default)]
+    pub sync: SyncConfig,
 }
 
 impl UserConfig {

--- a/sapphire-journal/Cargo.toml
+++ b/sapphire-journal/Cargo.toml
@@ -13,10 +13,11 @@ name = "sajo"
 path = "src/main.rs"
 
 [features]
-default = ["sqlite-store", "lancedb-store", "fastembed-embed"]
+default = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync"]
 sqlite-store = ["sapphire-journal-core/sqlite-store"]
 lancedb-store = ["sapphire-journal-core/lancedb-store"]
 fastembed-embed = ["sapphire-journal-core/fastembed-embed"]
+git-sync = ["sapphire-journal-core/git-sync"]
 
 [dependencies]
 clap.workspace = true

--- a/sapphire-journal/src/commands/mcp.rs
+++ b/sapphire-journal/src/commands/mcp.rs
@@ -12,6 +12,7 @@ use sapphire_journal_core::{
     user_config::UserConfig,
     JournalState, RetrieveDb,
 };
+use tokio::time;
 use rmcp::{
     ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
@@ -495,6 +496,7 @@ impl ArchelonServer {
                 if let Ok(conn) = s.open_conn() {
                     let _ = cache::upsert_entry_from_path(&conn, &dest, s.retrieve_db());
                 }
+                let _ = s.on_file_updated(&dest);
                 Ok(format!("created: {}", dest.display()))
             })
         })()
@@ -541,9 +543,13 @@ impl ArchelonServer {
                 let path = ops::resolve_entry(&p.entry, &conn)?;
                 let msg = if let Some(new_path) = ops::update_entry(&path, &conn, fields)? {
                     let _ = cache::upsert_entry_from_path(&conn, &new_path, s.retrieve_db());
+                    // File was renamed: remove old path and stage new path
+                    let _ = s.on_file_deleted(&path);
+                    let _ = s.on_file_updated(&new_path);
                     format!("updated and renamed: {}", new_path.display())
                 } else {
                     let _ = cache::upsert_entry_from_path(&conn, &path, s.retrieve_db());
+                    let _ = s.on_file_updated(&path);
                     format!("updated: {}", path.display())
                 };
                 Ok(msg)
@@ -584,12 +590,25 @@ impl ArchelonServer {
                 ops::resolve_entry(&p.entry, &conn).map_err(Into::into)
             })?;
             match ops::fix_entry(&path)? {
-                Some(new_path) => Ok(format!(
-                    "renamed: {} → {}",
-                    path.file_name().unwrap_or_default().to_string_lossy(),
-                    new_path.file_name().unwrap_or_default().to_string_lossy(),
-                )),
-                None => Ok(format!("ok: {} (already correct)", path.display())),
+                Some(new_path) => {
+                    self.with_state(|s| {
+                        let _ = s.on_file_deleted(&path);
+                        let _ = s.on_file_updated(&new_path);
+                        Ok(())
+                    })?;
+                    Ok(format!(
+                        "renamed: {} → {}",
+                        path.file_name().unwrap_or_default().to_string_lossy(),
+                        new_path.file_name().unwrap_or_default().to_string_lossy(),
+                    ))
+                }
+                None => {
+                    self.with_state(|s| {
+                        let _ = s.on_file_updated(&path);
+                        Ok(())
+                    })?;
+                    Ok(format!("ok: {} (already correct)", path.display()))
+                }
             }
         })()
         .map_err(|e| e.to_string())
@@ -604,7 +623,23 @@ impl ArchelonServer {
                 let path = ops::resolve_entry(&p.entry, &conn)?;
                 ops::remove_entry(&path)?;
                 let _ = cache::remove_from_cache(&conn, &path, s.retrieve_db());
+                let _ = s.on_file_deleted(&path);
                 Ok(format!("removed: {}", path.display()))
+            })
+        })()
+        .map_err(|e| e.to_string())
+    }
+
+    #[tool(description = "Run a full git sync cycle: commit staged changes, fetch and merge from \
+        remote, then push. No-op when no git repository is found or sync is disabled.")]
+    fn git_sync(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
+        (|| -> anyhow::Result<String> {
+            self.with_state(|s| {
+                if !s.has_sync_backend() {
+                    return Ok("skipped: no sync backend configured".to_owned());
+                }
+                s.git_sync()?;
+                Ok("sync complete".to_owned())
             })
         })()
         .map_err(|e| e.to_string())
@@ -730,6 +765,31 @@ pub async fn run(journal_dir: Option<&Path>) -> anyhow::Result<()> {
     tracing_subscriber::fmt().with_writer(std::io::stderr).init();
 
     let server = ArchelonServer::new(journal_dir.map(|x| x.to_path_buf()));
+
+    // Spawn periodic git sync task if configured.
+    let state_for_sync = Arc::clone(&server.state);
+    let _sync_handle = {
+        let interval = UserConfig::load()
+            .ok()
+            .and_then(|c| c.sync.sync_interval());
+        interval.map(|dur| {
+            tokio::spawn(async move {
+                let mut ticker = time::interval(dur);
+                ticker.tick().await; // skip the first immediate tick
+                loop {
+                    ticker.tick().await;
+                    let guard = state_for_sync.lock().unwrap();
+                    if let Some(state) = guard.as_ref() {
+                        if let Err(e) = state.git_sync() {
+                            eprintln!("[sapphire-journal] periodic git sync failed: {e}");
+                        }
+                    }
+                    drop(guard);
+                }
+            })
+        })
+    };
+
     let service = server.serve(stdio()).await?;
     service.waiting().await?;
     Ok(())


### PR DESCRIPTION
## Summary

- Enable the `git-sync` feature from `sapphire-workspace` to automatically stage entry file changes via `SyncBackend` (git add/rm) after every create, modify, fix, and remove operation
- Add a `git_sync` MCP tool for on-demand commit → pull → push cycles
- Spawn a background periodic sync timer in the MCP server, configurable via `sync.sync_interval_minutes` in user config (`~/.config/sapphire-journal/config.toml`)

## Configuration

```toml
[sync]
backend = "auto"              # "auto" | "git" | "none"
# remote = "origin"
sync_interval_minutes = 30    # periodic full sync interval (0 or omit to disable)
```

## Test plan

- [ ] Verify `cargo check` and `cargo test` pass with default features
- [ ] Confirm `git-sync` feature compiles correctly (new `git2`/`libssh2-sys` deps resolve)
- [ ] Test MCP `git_sync` tool triggers commit + pull + push in a journal inside a git repo
- [ ] Test periodic sync fires at configured interval when `sync_interval_minutes` is set
- [ ] Verify entry operations (create, modify, fix, remove) stage files in git index
- [ ] Confirm no-op behavior when journal is not inside a git repo or `backend = "none"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)