### PR TITLE
Group Cargo patch version updates into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     groups:
       cargo-patch:
         update-types:
@@ -13,3 +14,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      cargo-patch:
+        update-types:
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- Add a `cargo-patch` group in `dependabot.yml` to consolidate all Cargo patch version updates into a single PR
- Minor and major version updates remain as separate PRs, since they may introduce API changes

## Motivation

Patch versions are API-stable by semver contract, so batching them reduces noise without sacrificing review granularity where it matters.

## Test plan

- [ ] Confirm next dependabot run produces one grouped PR for Cargo patch updates
- [ ] Confirm minor/major Cargo updates still appear as individual PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)