### PR TITLE
chore(release): bump CLI to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "grain-id",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Markdown-based task and note manager that keeps your data alive a
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-journal"
 edition = "2024"
-version = "0.10.0"
+version = "0.11.0"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/sapphire-journal-dioxus/Cargo.toml
+++ b/sapphire-journal-dioxus/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 repository.workspace = true
 
 [dependencies]
-sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.10.0" }
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.0" }
 dioxus = { version = "0.7.5", features = [] }
 git2 = { version = "0.20", default-features = false }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/sapphire-journal/CHANGELOG.md
+++ b/sapphire-journal/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `sapphire-journal` and `sapphire-journal-core` are documented here.
 
+## [0.11.0] - 2026-04-12
+
+### Changed
+
+- `sapphire-workspace` bumped from 0.5.1 to 0.8.0
+- `rmcp` bumped to 1.4.0
+
 ## [0.10.0] - 2026-04-10
 
 ### Changed

--- a/sapphire-journal/Cargo.toml
+++ b/sapphire-journal/Cargo.toml
@@ -21,7 +21,7 @@ git-sync = ["sapphire-journal-core/git-sync"]
 
 [dependencies]
 clap.workspace = true
-sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.10.0", default-features = false }
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.0", default-features = false }
 rmcp.workspace = true
 tokio = { workspace = true, features = ["full"] }
 serde.workspace = true


### PR DESCRIPTION
## Summary

- Bump workspace version `0.10.0` → `0.11.0`
- Update `sapphire-journal-core` dependency version in `sapphire-journal` and `sapphire-journal-dioxus`
- Add `[0.11.0]` entry to `CHANGELOG.md`

## Changes

### Dependencies
- `sapphire-workspace` bumped from 0.5.1 to 0.8.0
- `rmcp` bumped to 1.4.0

## Test plan

- [ ] Merging this PR into `main` triggers the `Release CLI` workflow
- [ ] `sapphire-journal-core` and `sapphire-journal` are published to crates.io
- [ ] Tag `cli-v0.11.0` is created and release artifacts are uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)