### PR TITLE
chore(release): bump VSCode extension to v0.11.0

### DIFF
--- a/sapphire-journal-vscode/CHANGELOG.md
+++ b/sapphire-journal-vscode/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `sapphire-journal-vscode` are documented here.
 
+## [0.11.0] - 2026-04-12
+
+### Changed
+
+- Bundled `sapphire-journal` CLI updated to 0.11.0
+
 ## [0.10.0] - 2026-04-10
 
 ### Added

--- a/sapphire-journal-vscode/package.json
+++ b/sapphire-journal-vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Sapphire Journal",
   "publisher": "fluo10",
   "description": "VS Code extension for the Sapphire Journal",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/fluo10/sapphire-journal"


### PR DESCRIPTION
## Summary

- Bump `sapphire-journal-vscode` version `0.10.0` → `0.11.0`
- Add `[0.11.0]` entry to VSCode `CHANGELOG.md`

## Changes

### Changed
- Bundled `sapphire-journal` CLI updated to 0.11.0

## Test plan

- [ ] Merging this PR into `main` triggers the `Release VSCode Extension` workflow
- [ ] Platform-specific VSIX files are built and uploaded as release artifacts
- [ ] Extension is published to VS Code Marketplace and Open VSX Registry under tag `vscode-v0.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)