### PR TITLE
chore(release): bump version to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1457,6 +1457,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -3338,8 +3339,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -3920,7 +3921,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6630,7 +6631,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7423,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7440,7 +7441,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "chrono",
  "grain-id",
@@ -7472,9 +7473,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d369d570d92c3ce2683ebc8746d9ca938a503e02df5ff435f9bdcf7f9fe6e57"
+checksum = "59ca84d99b7765b10ad953e807d446efd3e1a4334f376ae9e7b0dcccf27e9344"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -7492,22 +7493,23 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485cacfc214c21b76a3040f680e26f66d3d4e808fa22e82979be5277b7aeba3c"
+checksum = "d4608abffd1b47b2aad94768791dd8c1b9a79f7614ba634979b5427a454e0e8e"
 dependencies = [
  "dirs 5.0.1",
  "git2",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e12489ac2e45d0ba8549538f7a4704df1fe869e8c1c4136254d5fe76f957e"
+checksum = "b201cfc43b44309ebc5ebd26436ec2f91453bc0f13e63ef1868357d056e6bac3"
 dependencies = [
  "dirs 5.0.1",
  "indexmap 2.13.1",
@@ -7987,7 +7989,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7999,7 +8001,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8479,7 +8481,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -9543,7 +9545,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -9567,7 +9569,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -9614,7 +9616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -9626,7 +9628,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -9643,25 +9645,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -9706,7 +9695,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -10232,7 +10221,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Markdown-based task and note manager that keeps your data alive a
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/sapphire-journal"
 edition = "2024"
-version = "0.11.0"
+version = "0.11.1"
 
 [workspace.dependencies]
 anyhow = "1"

--- a/sapphire-journal-core/Cargo.toml
+++ b/sapphire-journal-core/Cargo.toml
@@ -27,5 +27,5 @@ serde_json.workspace = true
 schemars.workspace = true
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-sapphire-workspace = { version = "0.8.0", default-features = false }
+sapphire-workspace = { version = "0.8.1", default-features = false }
 grain-id = { version = "0.14", features = ["serde", "rusqlite", "schemars"] }

--- a/sapphire-journal-dioxus/Cargo.toml
+++ b/sapphire-journal-dioxus/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 repository.workspace = true
 
 [dependencies]
-sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.0" }
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.1" }
 dioxus = { version = "0.7.5", features = [] }
 git2 = { version = "0.20", default-features = false }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/sapphire-journal/CHANGELOG.md
+++ b/sapphire-journal/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `sapphire-journal` and `sapphire-journal-core` are documented here.
 
+## [0.11.1] - 2026-04-13
+
+### Fixed
+
+- `sapphire-workspace` bumped from 0.8.0 to 0.8.1 (fixes sync-related bug)
+
 ## [0.11.0] - 2026-04-12
 
 ### Changed

--- a/sapphire-journal/Cargo.toml
+++ b/sapphire-journal/Cargo.toml
@@ -21,7 +21,7 @@ git-sync = ["sapphire-journal-core/git-sync"]
 
 [dependencies]
 clap.workspace = true
-sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.0", default-features = false }
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.1", default-features = false }
 rmcp.workspace = true
 tokio = { workspace = true, features = ["full"] }
 serde.workspace = true


### PR DESCRIPTION
## Summary

- `sapphire-workspace` 0.8.0 → 0.8.1 (picks up sync bug fix)
- Workspace version 0.11.0 → 0.11.1 (patch release)

## Test plan

- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)