### PR TITLE
chore(release): bump vscode extension to 0.11.1

### DIFF
--- a/sapphire-journal-vscode/CHANGELOG.md
+++ b/sapphire-journal-vscode/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `sapphire-journal-vscode` are documented here.
 
+## [0.11.1] - 2026-04-14
+
+### Changed
+
+- Bundled `sapphire-journal` CLI updated to 0.11.1
+- Re-run release workflow to publish the VSIX (0.11.0 release workflow failed with `ERR_PNPM_BROKEN_LOCKFILE`)
+
 ## [0.11.0] - 2026-04-12
 
 ### Changed

--- a/sapphire-journal-vscode/package.json
+++ b/sapphire-journal-vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Sapphire Journal",
   "publisher": "fluo10",
   "description": "VS Code extension for the Sapphire Journal",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/fluo10/sapphire-journal"


### PR DESCRIPTION
## Summary

- Bump VSCode extension to 0.11.1
- Bundled `sapphire-journal` CLI updated to 0.11.1
- Re-run release workflow: the 0.11.0 release failed with `ERR_PNPM_BROKEN_LOCKFILE` ([run](https://github.com/fluo10/sapphire-journal/actions/runs/24304039218)) so the VSIX was never published

## Test plan

- [ ] Release workflow `release-vscode.yml` succeeds on merge
- [ ] Tag `vscode-v0.11.1` is created
- [ ] VSIX artifacts published to GitHub Release, VS Code Marketplace, and Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)