### PR TITLE
chore(release): bump vscode extension to 0.11.2

### DIFF
--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         with:
           package_json_file: sapphire-journal-vscode/package.json
 

--- a/sapphire-journal-vscode/CHANGELOG.md
+++ b/sapphire-journal-vscode/CHANGELOG.md
@@ -2,16 +2,22 @@
 
 All notable changes to `sapphire-journal-vscode` are documented here.
 
+## [0.11.2] - 2026-04-14
+
+### Changed
+
+- Bumped pnpm from 10.30.3 to 10.33.0
+
+### Fixed
+
+- Release workflow now pins `pnpm/action-setup` to v5 to avoid the broken lockfile failure introduced by v6's pnpm 11 support; 0.11.1 was tagged but its VSIX was never published because the release workflow hit `ERR_PNPM_BROKEN_LOCKFILE`
+
 ## [0.11.1] - 2026-04-14
 
 ### Changed
 
 - Bundled `sapphire-journal` CLI updated to 0.11.1
-- Bumped pnpm from 10.30.3 to 10.33.0
-
-### Fixed
-
-- Release workflow now pins `pnpm/action-setup` to v5 to avoid the broken lockfile failure introduced by v6's pnpm 11 support (which caused the 0.11.0 release workflow to fail with `ERR_PNPM_BROKEN_LOCKFILE`)
+- Re-run release workflow to publish the VSIX (0.11.0 release workflow failed with `ERR_PNPM_BROKEN_LOCKFILE`)
 
 ## [0.11.0] - 2026-04-12
 

--- a/sapphire-journal-vscode/CHANGELOG.md
+++ b/sapphire-journal-vscode/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to `sapphire-journal-vscode` are documented here.
 ### Changed
 
 - Bundled `sapphire-journal` CLI updated to 0.11.1
-- Re-run release workflow to publish the VSIX (0.11.0 release workflow failed with `ERR_PNPM_BROKEN_LOCKFILE`)
+- Bumped pnpm from 10.30.3 to 10.33.0
+
+### Fixed
+
+- Release workflow now pins `pnpm/action-setup` to v5 to avoid the broken lockfile failure introduced by v6's pnpm 11 support (which caused the 0.11.0 release workflow to fail with `ERR_PNPM_BROKEN_LOCKFILE`)
 
 ## [0.11.0] - 2026-04-12
 

--- a/sapphire-journal-vscode/package.json
+++ b/sapphire-journal-vscode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sapphire-journal",
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@10.33.0",
   "displayName": "Sapphire Journal",
   "publisher": "fluo10",
   "description": "VS Code extension for the Sapphire Journal",

--- a/sapphire-journal-vscode/package.json
+++ b/sapphire-journal-vscode/package.json
@@ -4,7 +4,7 @@
   "displayName": "Sapphire Journal",
   "publisher": "fluo10",
   "description": "VS Code extension for the Sapphire Journal",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/fluo10/sapphire-journal"


### PR DESCRIPTION
## Summary

- Pin `pnpm/action-setup` to v5 in `release-vscode.yml` (v6's pnpm 11 support broke `pnpm install --frozen-lockfile` with `ERR_PNPM_BROKEN_LOCKFILE`)
- Bump pnpm from 10.30.3 to 10.33.0 (latest stable)
- Bump extension version to 0.11.2 to re-trigger the release workflow (0.11.1 was tagged but never published; [failed run](https://github.com/fluo10/sapphire-journal/actions/runs/24378739200))

## Test plan

- [ ] Release workflow `release-vscode.yml` succeeds on merge
- [ ] Tag `vscode-v0.11.2` is created
- [ ] VSIX artifacts published to GitHub Release, VS Code Marketplace, and Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)