### PR TITLE
feat(deps): upgrade sapphire-workspace to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,7 +705,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1457,7 +1457,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.117",
 ]
 
@@ -3339,8 +3338,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -6631,7 +6630,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7474,9 +7473,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ca84d99b7765b10ad953e807d446efd3e1a4334f376ae9e7b0dcccf27e9344"
+checksum = "1ad4bad23eedba96b695a389bd325b030a9452330c9ab54cf50db5adbeb8b636"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -7494,9 +7493,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4608abffd1b47b2aad94768791dd8c1b9a79f7614ba634979b5427a454e0e8e"
+checksum = "14262216508f61acf2a9c387065be8ad633068cea469d8ac390bafc77ccc7565"
 dependencies = [
  "dirs 5.0.1",
  "git2",
@@ -7508,9 +7507,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b201cfc43b44309ebc5ebd26436ec2f91453bc0f13e63ef1868357d056e6bac3"
+checksum = "4d65ac73122bbaa09fba44072d37a6e510e2d63ecd1c266903aecf5f70e626a2"
 dependencies = [
  "dirs 5.0.1",
  "indexmap 2.13.1",
@@ -7990,7 +7989,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8002,7 +8001,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/sapphire-journal-core/Cargo.toml
+++ b/sapphire-journal-core/Cargo.toml
@@ -27,5 +27,5 @@ serde_json.workspace = true
 schemars.workspace = true
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-sapphire-workspace = { version = "0.8.1", default-features = false }
+sapphire-workspace = { version = "0.9.0", default-features = false }
 grain-id = { version = "0.14", features = ["serde", "rusqlite", "schemars"] }

--- a/sapphire-journal-core/src/cache.rs
+++ b/sapphire-journal-core/src/cache.rs
@@ -177,8 +177,6 @@ pub fn sync_cache(
 
     let db_files = retrieve.file_mtimes()?;
 
-    let mut entry_changed = false;
-
     conn.execute_batch("PRAGMA defer_foreign_keys=ON; BEGIN")?;
 
     // ── delete files removed from disk ───────────────────────────────────────
@@ -196,7 +194,6 @@ pub fn sync_cache(
             conn.execute("DELETE FROM entries WHERE path = ?1", [db_path])?;
             let _ = retrieve.remove_file(db_path);
             if let Some(id) = entry_id {
-                entry_changed = true;
                 let _ = retrieve.remove_document(id);
             }
         }
@@ -219,7 +216,6 @@ pub fn sync_cache(
                     upsert_entry(conn, &entry)?;
                     let doc = entry_to_document(&entry);
                     let _ = retrieve.upsert_document(&doc);
-                    entry_changed = true;
                 }
                 Err(e) => {
                     let _ = retrieve.upsert_file(path_str.as_ref(), *mtime);
@@ -260,10 +256,6 @@ pub fn sync_cache(
     }
 
     conn.execute_batch("COMMIT")?;
-
-    if entry_changed {
-        let _ = retrieve.rebuild_fts();
-    }
 
     Ok(())
 }
@@ -452,7 +444,6 @@ pub fn upsert_entry_from_path(
     upsert_entry(conn, &entry)?;
     let doc = entry_to_document(&entry);
     let _ = retrieve.upsert_document(&doc);
-    let _ = retrieve.rebuild_fts();
     Ok(())
 }
 
@@ -628,7 +619,6 @@ fn upsert_entry(conn: &Connection, entry: &crate::entry::Entry) -> Result<()> {
 fn entry_to_document(entry: &crate::entry::Entry) -> sapphire_workspace::Document {
     sapphire_workspace::Document {
         id: u64::from(entry.frontmatter.id) as i64,
-        title: entry.frontmatter.title.clone(),
         body: entry.body.clone(),
         path: entry.path.to_string_lossy().into_owned(),
         chunks: None,

--- a/sapphire-journal-core/src/lib.rs
+++ b/sapphire-journal-core/src/lib.rs
@@ -34,8 +34,8 @@ pub mod user_config;
 pub use journal_state::JournalState;
 #[allow(deprecated)]
 pub use sapphire_workspace::RetrieveDb;
-pub use sapphire_workspace::dedup_chunk_results;
 pub use sapphire_workspace::SyncBackend;
+pub use sapphire_workspace::{FtsQuery, VectorQuery};
 #[cfg(feature = "git-sync")]
 pub use sapphire_workspace::GitSync;
 

--- a/sapphire-journal/src/commands/entry.rs
+++ b/sapphire-journal/src/commands/entry.rs
@@ -9,6 +9,7 @@ use sapphire_journal_core::{
     user_config::UserConfig,
     JournalState,
 };
+use sapphire_journal_core::{FtsQuery, VectorQuery};
 
 use chrono::NaiveDateTime;
 use clap::{Args, Subcommand};
@@ -707,26 +708,22 @@ fn search(state: &JournalState, query: &str, semantic: bool, limit: usize) -> Re
                  for semantic search"
             )
         })?;
-        let query_vec = embedder.embed_texts(&[query])
-            .map_err(anyhow::Error::msg)?
-            .into_iter()
-            .next()
-            .ok_or_else(|| anyhow::anyhow!("embedding API returned empty result"))?;
 
-        let raw = state.retrieve_db().search_similar(&query_vec, limit * 3)
+        let q = VectorQuery::new(query, embedder).limit(limit);
+        let results = state.retrieve_db().search_similar(&q)
             .map_err(anyhow::Error::msg)?;
-        if raw.is_empty() {
+        if results.is_empty() {
             println!("no results");
             return Ok(());
         }
-        let results = sapphire_journal_core::dedup_chunk_results(raw, limit);
         for r in &results {
-            println!("{:.4}  {}  {}", r.score, r.title, r.path);
+            println!("{:.4}  {}", r.score, r.path);
         }
     } else {
         // ── full-text search (FTS5 trigram) ───────────────────────────────────
         state.sync()?;
-        let results = state.retrieve_db().search_fts(query, limit)
+        let q = FtsQuery::new(query).limit(limit);
+        let results = state.retrieve_db().search_fts(&q)
             .map_err(anyhow::Error::msg)?;
 
         if results.is_empty() {
@@ -735,7 +732,6 @@ fn search(state: &JournalState, query: &str, semantic: bool, limit: usize) -> Re
         }
         for r in &results {
             println!("{}", r.path);
-            println!("  {}", r.title);
         }
     }
 

--- a/sapphire-journal/src/commands/mcp.rs
+++ b/sapphire-journal/src/commands/mcp.rs
@@ -22,7 +22,7 @@ use rmcp::{
     tool, tool_router,
     transport::stdio,
 };
-use sapphire_journal_core::dedup_chunk_results;
+use sapphire_journal_core::{FtsQuery, VectorQuery};
 use serde::Deserialize;
 
 // ── server struct ─────────────────────────────────────────────────────────────
@@ -749,18 +749,16 @@ impl ArchelonServer {
                         let _ = s.retrieve_db().embed_pending(embedder, |_, _| {});
                     }
 
-                    // Vector search: embed the query and find similar chunks.
-                    let query_vecs = embedder.embed_texts(&[p.query.as_str()])?;
-                    let query_vec = query_vecs.into_iter().next()
-                        .ok_or_else(|| anyhow::anyhow!("embedder returned empty result"))?;
-                    let raw = s.retrieve_db().search_similar(&query_vec, limit * 3)
+                    // Vector search.
+                    let q = VectorQuery::new(p.query.as_str(), embedder).limit(limit);
+                    let results = s.retrieve_db().search_similar(&q)
                         .map_err(anyhow::Error::msg)?;
-                    let results = dedup_chunk_results(raw, limit);
                     return Ok(serde_json::to_string_pretty(&results)?);
                 }
 
                 // Fallback: full-text search.
-                let results = s.retrieve_db().search_fts(&p.query, limit)
+                let q = FtsQuery::new(&p.query).limit(limit);
+                let results = s.retrieve_db().search_fts(&q)
                     .map_err(anyhow::Error::msg)?;
                 Ok(serde_json::to_string_pretty(&results)?)
             })


### PR DESCRIPTION
## Summary

- Bump `sapphire-workspace` from `0.8.1` to `0.9.0` in `sapphire-journal-core`
- Migrate all search call sites to the new query-builder API (`FtsQuery` / `VectorQuery`)
- Remove dropped items: `dedup_chunk_results`, `Document.title`, `rebuild_fts()`

## Breaking changes addressed

| Change in 0.9.0 | Adaptation |
|---|---|
| `search_fts(query, limit)` replaced by `search_fts(&FtsQuery)` | Updated all call sites in `cache.rs`, `entry.rs`, `mcp.rs` |
| `search_similar(vec, limit)` replaced by `search_similar(&VectorQuery)` — embedding done internally | Removed manual `embed_texts` + vector passing; pass query string + embedder directly |
| `dedup_chunk_results` removed | Removed re-export from `lib.rs` and all usages; `VectorQuery` already returns deduplicated `FileSearchResult` |
| `Document.title` field removed | Dropped from `entry_to_document` |
| `documents_fts` table removed → `rebuild_fts()` no longer needed | Removed both `rebuild_fts()` call sites; cleaned up the now-dead `entry_changed` variable |
| New public types `FtsQuery` / `VectorQuery` | Re-exported from `sapphire-journal-core::lib` so consumers keep a single dependency |

## Test plan

- [ ] `cargo check -p sapphire-journal-core` — no errors or warnings
- [ ] `cargo check -p sapphire-journal` — no errors or warnings
- [ ] Run `sajo entry search <query>` and verify FTS results are returned
- [ ] Run `sajo entry search --semantic <query>` and verify vector search results are returned
- [ ] Verify MCP `entry_search` tool returns well-formed JSON with the new `FileSearchResult` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)