### PR TITLE
docs(config): add example config files with parse test

### DIFF
--- a/docs/config/journal-config.toml
+++ b/docs/config/journal-config.toml
@@ -1,0 +1,16 @@
+# Example per-journal config for sapphire-journal.
+#
+# Location: <journal-root>/.sapphire-journal/config.toml
+#
+# This file is committed to the journal repo and shared across all machines
+# that open the journal. Keep host-specific settings (cache backend, embedding
+# API keys, sync cadence) in the user-level config instead.
+
+[journal]
+# How to handle two entries with the same title during cache sync.
+# "allow" | "warn" (default) | "error"
+duplicate_title = "warn"
+
+# Sub-directory (relative to the journal root) where year directories are
+# created. When unset, year directories live directly under the journal root.
+# entries_dir = "entries"

--- a/docs/config/user-config.toml
+++ b/docs/config/user-config.toml
@@ -1,0 +1,46 @@
+# Example user-level config for sapphire-journal.
+#
+# Location: $XDG_CONFIG_HOME/sapphire-journal/config.toml
+#          (typically ~/.config/sapphire-journal/config.toml)
+#
+# This file holds host/machine-specific settings (cache backend, embedding
+# provider, sync cadence). It is intentionally separate from the per-journal
+# `.sapphire-journal/config.toml` so that the same journal can be shared
+# across machines with different hardware capabilities.
+
+# ── Retrieve cache ───────────────────────────────────────────────────────────
+[cache.retrieve]
+# "none" | "sqlite_vec" | "lancedb"
+db = "sqlite_vec"
+
+# How often to refresh the retrieve cache (full-text + vector index).
+# Omit or set to 0 to disable periodic refresh.
+# sync_interval_minutes = 15
+
+[cache.retrieve.embedding]
+enabled     = true
+provider    = "openai"
+model       = "text-embedding-3-small"
+dimension   = 1536
+api_key_env = "OPENAI_API_KEY"
+
+# For local providers (Ollama, fastembed, etc.):
+# provider  = "ollama"
+# model     = "nomic-embed-text"
+# dimension = 768
+# base_url  = "http://localhost:11434"
+
+# ── Git sync ─────────────────────────────────────────────────────────────────
+[sync]
+# "auto" | "git" | "none"
+backend = "git"
+remote  = "origin"
+branch  = "main"
+
+# Run a full sync cycle (commit → fetch → merge → push) every N minutes.
+# Picked up by the MCP server's periodic sync task.
+# Omit or set to 0 to disable periodic sync.
+sync_interval_minutes = 30
+
+# Optional stable device identifier used in auto-generated commit messages.
+# device_id = "laptop-home"

--- a/sapphire-journal-core/tests/example_configs.rs
+++ b/sapphire-journal-core/tests/example_configs.rs
@@ -1,0 +1,18 @@
+//! Verify that the example config files under `docs/config/` stay in sync
+//! with the `UserConfig` / `JournalConfig` schemas.
+
+use sapphire_journal_core::journal::JournalConfig;
+use sapphire_journal_core::user_config::UserConfig;
+
+#[test]
+fn user_config_example_parses() {
+    let raw = include_str!("../../docs/config/user-config.toml");
+    toml::from_str::<UserConfig>(raw).expect("docs/config/user-config.toml must parse as UserConfig");
+}
+
+#[test]
+fn journal_config_example_parses() {
+    let raw = include_str!("../../docs/config/journal-config.toml");
+    toml::from_str::<JournalConfig>(raw)
+        .expect("docs/config/journal-config.toml must parse as JournalConfig");
+}


### PR DESCRIPTION
## Summary
- Add annotated example configs under `docs/config/`:
  - `user-config.toml` — user-level (`~/.config/sapphire-journal/config.toml`): cache/embedding/sync backend and periodic sync cadence
  - `journal-config.toml` — per-journal (`.sapphire-journal/config.toml`): `duplicate_title`, `entries_dir`
- Add `sapphire-journal-core/tests/example_configs.rs` that parses both files as `UserConfig` / `JournalConfig` via `include_str!`, so the examples cannot silently drift from the schemas (missing/renamed files fail at compile time)

## Test plan
- [x] `cargo test -p sapphire-journal-core --test example_configs` → 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)