### PR TITLE
feat(sync): enable periodic sync by default and surface settings to VS Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7475,9 +7475,9 @@ dependencies = [
 
 [[package]]
 name = "sapphire-retrieve"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4bad23eedba96b695a389bd325b030a9452330c9ab54cf50db5adbeb8b636"
+checksum = "3e6f5aa427c2882c399232edf42457e5902e30ce773807dbe9333fe8cf6aab62"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -7495,13 +7495,15 @@ dependencies = [
 
 [[package]]
 name = "sapphire-sync"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14262216508f61acf2a9c387065be8ad633068cea469d8ac390bafc77ccc7565"
+checksum = "cba21afe17e54475e34feabf7467af1d03e0f305c729e593b5f0d987e9a5d1e2"
 dependencies = [
+ "chrono",
  "dirs 5.0.1",
  "git2",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
@@ -7509,11 +7511,11 @@ dependencies = [
 
 [[package]]
 name = "sapphire-workspace"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d65ac73122bbaa09fba44072d37a6e510e2d63ecd1c266903aecf5f70e626a2"
+checksum = "303d36580d0e6ac3809e5101a0fe2bf39b4c8af7292be182655ed1a69efbaf84"
 dependencies = [
- "dirs 5.0.1",
+ "chrono",
  "indexmap 2.13.1",
  "md-5",
  "sapphire-retrieve",
@@ -7522,6 +7524,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
  "uuid",
  "walkdir",
 ]

--- a/sapphire-journal-core/Cargo.toml
+++ b/sapphire-journal-core/Cargo.toml
@@ -27,5 +27,5 @@ serde_json.workspace = true
 schemars.workspace = true
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-sapphire-workspace = { version = "0.9.0", default-features = false }
+sapphire-workspace = { version = "0.10.0", default-features = false }
 grain-id = { version = "0.14", features = ["serde", "rusqlite", "schemars"] }

--- a/sapphire-journal-core/src/user_config.rs
+++ b/sapphire-journal-core/src/user_config.rs
@@ -1,11 +1,24 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
-pub use sapphire_workspace::{EmbeddingConfig, RetrieveConfig, SyncConfig, VectorDb};
+pub use sapphire_workspace::{EmbeddingConfig, RetrieveConfig, SyncBackendKind, SyncConfig, VectorDb};
+
+/// Default cadence (minutes) for periodic sync when nothing is configured.
+///
+/// Periodic sync is enabled by default at this interval. The MCP server
+/// also drives an incremental cache + retrieve refresh on the same tick, so
+/// even workspaces without a git sync backend benefit from having it on.
+/// Set `sync_interval_minutes = 0` to opt out.
+const DEFAULT_SYNC_INTERVAL_MINUTES: u32 = 10;
+
+fn default_sync_interval_minutes() -> Option<u32> {
+    Some(DEFAULT_SYNC_INTERVAL_MINUTES)
+}
 
 /// Contents of `$XDG_CONFIG_HOME/sapphire-journal/config.toml`.
 ///
@@ -13,7 +26,7 @@ pub use sapphire_workspace::{EmbeddingConfig, RetrieveConfig, SyncConfig, Vector
 /// settings such as caching backends. It is intentionally separate from the
 /// per-journal `.sapphire-journal/config.toml` so that the same journal can be
 /// shared across machines with different hardware capabilities.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserConfig {
     #[serde(default)]
     pub cache: CacheConfig,
@@ -21,9 +34,33 @@ pub struct UserConfig {
     /// Sync backend configuration (`[sync]` section).
     #[serde(default)]
     pub sync: SyncConfig,
+
+    /// How often to run periodic sync, in minutes.
+    ///
+    /// Defaults to 10 minutes. Set to `0` to disable.
+    #[serde(default = "default_sync_interval_minutes", skip_serializing_if = "Option::is_none")]
+    pub sync_interval_minutes: Option<u32>,
+}
+
+impl Default for UserConfig {
+    fn default() -> Self {
+        Self {
+            cache: CacheConfig::default(),
+            sync: SyncConfig::default(),
+            sync_interval_minutes: default_sync_interval_minutes(),
+        }
+    }
 }
 
 impl UserConfig {
+    /// Periodic sync cadence as a [`Duration`]. Returns `None` when disabled
+    /// (`sync_interval_minutes = 0`).
+    pub fn sync_interval(&self) -> Option<Duration> {
+        self.sync_interval_minutes
+            .filter(|&m| m > 0)
+            .map(|m| Duration::from_secs(u64::from(m) * 60))
+    }
+
     /// Canonical path to the user config file.
     ///
     /// Resolves to `$XDG_CONFIG_HOME/sapphire-journal/config.toml`.
@@ -46,6 +83,8 @@ impl UserConfig {
     /// | `SAPPHIRE_JOURNAL_CACHE_EMBEDDING_API_KEY_ENV` | `cache.retrieve.embedding.api_key_env` |
     /// | `SAPPHIRE_JOURNAL_CACHE_EMBEDDING_BASE_URL` | `cache.retrieve.embedding.base_url` |
     /// | `SAPPHIRE_JOURNAL_CACHE_EMBEDDING_DIMENSION` | `cache.retrieve.embedding.dimension` |
+    /// | `SAPPHIRE_JOURNAL_SYNC_BACKEND` | `sync.backend` (`auto`/`none`/`git`) |
+    /// | `SAPPHIRE_JOURNAL_SYNC_INTERVAL_MINUTES` | `sync_interval_minutes` |
     pub fn load() -> Result<Self> {
         let path = Self::path();
         let mut config = if !path.exists() {
@@ -95,6 +134,27 @@ impl UserConfig {
             if let Some(v) = base_url { embed.base_url = Some(v); }
             if let Some(v) = dimension { embed.dimension = Some(v); }
         }
+
+        if let Ok(v) = std::env::var("SAPPHIRE_JOURNAL_SYNC_BACKEND") {
+            if let Some(backend) = parse_sync_backend(&v) {
+                self.sync.backend = backend;
+            }
+        }
+        if let Ok(v) = std::env::var("SAPPHIRE_JOURNAL_SYNC_INTERVAL_MINUTES") {
+            if let Ok(n) = v.parse::<u32>() {
+                self.sync_interval_minutes = Some(n);
+            }
+        }
+    }
+}
+
+fn parse_sync_backend(s: &str) -> Option<sapphire_workspace::SyncBackendKind> {
+    use sapphire_workspace::SyncBackendKind;
+    match s {
+        "auto" => Some(SyncBackendKind::Auto),
+        "none" => Some(SyncBackendKind::None),
+        "git" => Some(SyncBackendKind::Git),
+        _ => None,
     }
 }
 

--- a/sapphire-journal-vscode/package.json
+++ b/sapphire-journal-vscode/package.json
@@ -220,6 +220,11 @@
           ],
           "description": "Vector database backend for semantic search. Overrides config.toml when set."
         },
+        "sapphire-journal.cache.embedding.enabled": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": "Enable embedding-based semantic search. Leave unset to inherit config.toml; set true/false to override."
+        },
         "sapphire-journal.cache.embedding.provider": {
           "type": "string",
           "default": "",
@@ -244,6 +249,29 @@
           "type": "string",
           "default": "",
           "description": "Output vector dimension of the embedding model (e.g. 1536, 768). Overrides config.toml when set."
+        },
+        "sapphire-journal.syncIntervalMinutes": {
+          "type": ["integer", "null"],
+          "default": null,
+          "minimum": 0,
+          "description": "How often the MCP server runs periodic sync (commit/pull/push when a git backend is attached, plus cache refresh), in minutes. Leave unset to inherit config.toml (default: 10). Set to 0 to disable."
+        },
+        "sapphire-journal.sync.backend": {
+          "type": "string",
+          "default": "",
+          "enum": [
+            "",
+            "auto",
+            "none",
+            "git"
+          ],
+          "enumDescriptions": [
+            "Use the value from config.toml",
+            "Auto-detect: git when inside a git repo, otherwise local-only",
+            "Disable sync (local-only) even inside a git repository",
+            "Force git-based sync (commit → pull → push)"
+          ],
+          "description": "Sync backend. Overrides config.toml when set."
         }
       }
     }

--- a/sapphire-journal-vscode/src/cli.ts
+++ b/sapphire-journal-vscode/src/cli.ts
@@ -7,31 +7,44 @@ let _extensionPath: string | undefined;
 /**
  * Build environment variable overrides from VSCode settings.
  *
- * Any `sapphire-journal.cache.*` setting with a non-empty value is translated to the
- * corresponding `ARCHELON_CACHE_*` environment variable so that the CLI treats
- * VSCode settings as overrides on top of `config.toml`.
+ * Any `sapphire-journal.*` setting with a non-default value is translated to
+ * the corresponding `SAPPHIRE_JOURNAL_*` environment variable so that the CLI
+ * treats VSCode settings as overrides on top of `config.toml`.
  */
 export function configEnv(): Record<string, string> {
     const cfg = vscode.workspace.getConfiguration('sapphire-journal');
     const env: Record<string, string> = {};
 
     const vectorDb = cfg.get<string>('cache.vectorDb', '');
-    if (vectorDb) { env['ARCHELON_CACHE_VECTOR_DB'] = vectorDb; }
+    if (vectorDb) { env['SAPPHIRE_JOURNAL_CACHE_RETRIEVE_DB'] = vectorDb; }
+
+    const embeddingEnabled = cfg.get<boolean | null>('cache.embedding.enabled', null);
+    if (embeddingEnabled !== null && embeddingEnabled !== undefined) {
+        env['SAPPHIRE_JOURNAL_CACHE_EMBEDDING_ENABLED'] = embeddingEnabled ? 'true' : 'false';
+    }
 
     const provider = cfg.get<string>('cache.embedding.provider', '');
-    if (provider) { env['ARCHELON_CACHE_EMBEDDING_PROVIDER'] = provider; }
+    if (provider) { env['SAPPHIRE_JOURNAL_CACHE_EMBEDDING_PROVIDER'] = provider; }
 
     const model = cfg.get<string>('cache.embedding.model', '');
-    if (model) { env['ARCHELON_CACHE_EMBEDDING_MODEL'] = model; }
+    if (model) { env['SAPPHIRE_JOURNAL_CACHE_EMBEDDING_MODEL'] = model; }
 
     const apiKeyEnv = cfg.get<string>('cache.embedding.apiKeyEnv', '');
-    if (apiKeyEnv) { env['ARCHELON_CACHE_EMBEDDING_API_KEY_ENV'] = apiKeyEnv; }
+    if (apiKeyEnv) { env['SAPPHIRE_JOURNAL_CACHE_EMBEDDING_API_KEY_ENV'] = apiKeyEnv; }
 
     const baseUrl = cfg.get<string>('cache.embedding.baseUrl', '');
-    if (baseUrl) { env['ARCHELON_CACHE_EMBEDDING_BASE_URL'] = baseUrl; }
+    if (baseUrl) { env['SAPPHIRE_JOURNAL_CACHE_EMBEDDING_BASE_URL'] = baseUrl; }
 
     const dimension = cfg.get<string>('cache.embedding.dimension', '');
-    if (dimension) { env['ARCHELON_CACHE_EMBEDDING_DIMENSION'] = dimension; }
+    if (dimension) { env['SAPPHIRE_JOURNAL_CACHE_EMBEDDING_DIMENSION'] = dimension; }
+
+    const syncBackend = cfg.get<string>('sync.backend', '');
+    if (syncBackend) { env['SAPPHIRE_JOURNAL_SYNC_BACKEND'] = syncBackend; }
+
+    const syncIntervalMinutes = cfg.get<number | null>('syncIntervalMinutes', null);
+    if (syncIntervalMinutes !== null && syncIntervalMinutes !== undefined) {
+        env['SAPPHIRE_JOURNAL_SYNC_INTERVAL_MINUTES'] = String(syncIntervalMinutes);
+    }
 
     return env;
 }

--- a/sapphire-journal/src/commands/mcp.rs
+++ b/sapphire-journal/src/commands/mcp.rs
@@ -868,7 +868,7 @@ pub async fn run(journal_dir: Option<&Path>) -> anyhow::Result<()> {
     let _sync_handle = {
         let interval = UserConfig::load()
             .ok()
-            .and_then(|c| c.sync.sync_interval());
+            .and_then(|c| c.sync_interval());
         interval.map(|dur| {
             tokio::spawn(async move {
                 let mut ticker = time::interval(dur);


### PR DESCRIPTION
## Summary

- **Default periodic sync ON (10 min)**: previously `sync_interval_minutes` was unset = disabled, leaving entries staged-but-uncommitted for users who only access the journal via the VS Code extension. Defaults to `Some(10)`; set `0` to opt out.
- **Surface sync settings to VS Code**: adds `syncIntervalMinutes`, `sync.backend`, and the missing `cache.embedding.enabled` to the extension settings, plus matching `SAPPHIRE_JOURNAL_SYNC_*` env-var overrides.
- **Fix env-var prefix bug**: extension was emitting `ARCHELON_CACHE_*` but the Rust side reads `SAPPHIRE_JOURNAL_CACHE_*` — every existing `cache.*` VS Code setting was silently ignored. Also corrects `VECTOR_DB` → `RETRIEVE_DB` to match the Rust key.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p sapphire-journal-core` (20 passed)
- [x] `pnpm compile` (tsc)
- [x] `pnpm lint` (eslint)
- [ ] Manual: restart VS Code on a journal workspace and confirm `[sapphire-journal] periodic git sync failed: …` does not appear in stderr after 10 min, and that staged changes get committed/pushed
- [ ] Manual: set `sapphire-journal.syncIntervalMinutes = 0` in VS Code settings and confirm timer is not spawned

🤖 Generated with [Claude Code](https://claude.com/claude-code)