### PR TITLE
feat(gui): initial egui-based desktop GUI for journals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ target
 tmp
 .archelon
 .cargo
+
+# macOS Finder metadata
+.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.2",
+ "raw-window-handle 0.6.2",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +649,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +686,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -2847,7 +2891,7 @@ dependencies = [
  "objc_id",
  "percent-encoding",
  "rand 0.9.2",
- "rfd",
+ "rfd 0.17.2",
  "rustc-hash 2.1.2",
  "serde",
  "serde_json",
@@ -4373,7 +4417,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.18",
- "windows 0.61.3",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -4758,7 +4802,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8499,6 +8543,30 @@ dependencies = [
 
 [[package]]
 name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "pollster",
+ "raw-window-handle 0.6.2",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rfd"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
@@ -8805,6 +8873,7 @@ dependencies = [
  "eframe",
  "egui",
  "git2",
+ "rfd 0.15.4",
  "sapphire-journal-core",
  "serde",
  "tokio",
@@ -10698,7 +10767,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -12562,6 +12638,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
+ "url",
  "winnow 1.0.1",
  "zvariant_derive",
  "zvariant_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
 name = "datafusion"
 version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3403,6 +3409,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_extras"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c609fc87f6c70ffd3afd679cbb294985096d2fc0be33e762ad5614bde4925bc"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "log",
+ "mime_guess2",
+ "profiling",
+ "resvg",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,6 +3475,26 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "enumflags2"
@@ -3751,6 +3792,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "fnv"
@@ -4964,6 +5011,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5289,6 +5342,17 @@ dependencies = [
  "html5ever",
  "indexmap 2.13.1",
  "selectors",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -6439,6 +6503,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime_guess2"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
+dependencies = [
+ "mime",
+ "phf 0.11.3",
+ "phf_shared 0.11.3",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7458,7 +7534,7 @@ checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
 dependencies = [
  "bytemuck",
  "color",
- "kurbo",
+ "kurbo 0.13.0",
  "linebender_resource_handle",
  "smallvec",
 ]
@@ -7513,6 +7589,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -7612,6 +7689,20 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicase",
+]
+
+[[package]]
+name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
@@ -7648,6 +7739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher 1.0.2",
+ "unicase",
 ]
 
 [[package]]
@@ -7667,6 +7759,12 @@ checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -8542,6 +8640,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8594,6 +8706,9 @@ name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -8653,6 +8768,12 @@ dependencies = [
  "bytemuck",
  "byteorder",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rsqlite-vfs"
@@ -8873,7 +8994,9 @@ dependencies = [
  "chrono",
  "eframe",
  "egui",
+ "egui_extras",
  "git2",
+ "grain-id",
  "rfd 0.15.4",
  "sapphire-journal-core",
  "serde",
@@ -9327,6 +9450,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9661,6 +9793,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "string_cache"
@@ -9748,6 +9883,16 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher 1.0.2",
+]
 
 [[package]]
 name = "syn"
@@ -10195,6 +10340,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -10776,6 +10922,28 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "simplecss",
+ "siphasher 1.0.2",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "xmlwriter",
+]
 
 [[package]]
 name = "utf-8"
@@ -12359,6 +12527,12 @@ name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,115 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5351dcebb14b579ccab05f288596b2ae097005be7ee50a7c3d4ca9d0d5a66f6a"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842fd8203e6dfcf531d24f5bac792088edfba7d6b35844fead191603fb32a260"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
+ "phf 0.13.1",
+ "serde",
+ "zvariant",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534bc3fdc89a64a1db3c46b33c198fde2b7c3c7d094e5809c8c8bf2970c18243"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_unix"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e549dd7c6562b6a2ea807b44726e6241707db054a817dc4c7e2b8d3b39bfac"
+dependencies = [
+ "accesskit",
+ "accesskit_atspi_common",
+ "async-channel",
+ "async-executor",
+ "async-task",
+ "atspi",
+ "futures-lite",
+ "futures-util",
+ "serde",
+ "zbus",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "accesskit_winit"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe9a94394896352cc4660ca2288bd4ef883d83238853c038b44070c8f134313"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_unix",
+ "accesskit_windows",
+ "raw-window-handle 0.6.2",
+ "winit",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +179,31 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.11.0",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "android_system_properties"
@@ -141,6 +275,26 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "arc-swap"
@@ -399,12 +553,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "as-raw-xcb-connection"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -432,6 +613,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +653,24 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -452,6 +683,30 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -510,6 +765,43 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "atspi"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77886257be21c9cd89a4ae7e64860c6f0eefca799bb79127913052bd0eefb3d"
+dependencies = [
+ "atspi-common",
+ "atspi-proxies",
+]
+
+[[package]]
+name = "atspi-common"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c5617155740c98003016429ad13fe43ce7a77b007479350a9f8bf95a29f63d"
+dependencies = [
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "atspi-proxies"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2230e48787ed3eb4088996eab66a32ca20c0b67bbd4fd6cdfe79f04f1f04c9fc"
+dependencies = [
+ "atspi-common",
+ "serde",
+ "zbus",
+]
 
 [[package]]
 name = "autocfg"
@@ -590,6 +882,21 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 
 [[package]]
 name = "bit_field"
@@ -682,11 +989,33 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -752,6 +1081,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -797,6 +1140,57 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "calloop"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+ "polling",
+ "rustix 0.38.44",
+ "slab",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.11.0",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
+dependencies = [
+ "calloop 0.13.0",
+ "rustix 0.38.44",
+ "wayland-backend",
+ "wayland-client",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop 0.14.4",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -864,6 +1258,15 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ced0551234e87afee12411d535648dd89d2e7f34c78b753395567aff3d447ff"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "chacha20"
@@ -941,6 +1344,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -965,8 +1377,28 @@ dependencies = [
  "bitflags 2.11.0",
  "block",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1215,13 +1647,26 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -1234,8 +1679,19 @@ checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1402,6 +1858,12 @@ checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "darling"
@@ -2676,15 +3138,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
 name = "dispatch2"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2696,6 +3164,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2729,6 +3206,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "downcast-rs"
@@ -2770,10 +3253,142 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecolor"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55f6cc0cb3b84a21232c468db972ebcddd34decbf1ff02cdebffd807c13bbd81"
+dependencies = [
+ "bytemuck",
+ "emath",
+]
+
+[[package]]
+name = "eframe"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea3080bfd001aee2223dcb2228d9de7d31f41d7cfb99e8cd70df3ae8083a42f"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "egui-wgpu",
+ "egui-winit",
+ "egui_glow",
+ "glutin",
+ "glutin-winit",
+ "image",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "pollster",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "wgpu",
+ "windows-sys 0.61.2",
+ "winit",
+]
+
+[[package]]
+name = "egui"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbe28ac1a9c0761319aafb9ad37737720cc49d99c13a4a6b990768fa01ffe67"
+dependencies = [
+ "accesskit",
+ "ahash",
+ "bitflags 2.11.0",
+ "emath",
+ "epaint",
+ "log",
+ "nohash-hasher",
+ "profiling",
+ "smallvec",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "egui-wgpu"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f311c0b9cdd8a38821ae6f245fbe6e1a3d7d157c77b7d22344f205b317232c8"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "document-features",
+ "egui",
+ "epaint",
+ "log",
+ "profiling",
+ "thiserror 2.0.18",
+ "type-map",
+ "web-time",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "egui-winit"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8e97625c2fe0fadc8b92ec690fbf515e15e2efd67ca50e063ad3302ec8ee626"
+dependencies = [
+ "accesskit_winit",
+ "arboard",
+ "bytemuck",
+ "egui",
+ "log",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "smithay-clipboard",
+ "web-time",
+ "webbrowser",
+ "winit",
+]
+
+[[package]]
+name = "egui_glow"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6caa4eca47cc2358e2c5ae60843a94118e338f87099c6af4170e6e968e8d77cb"
+dependencies = [
+ "bytemuck",
+ "egui",
+ "glow",
+ "log",
+ "memoffset",
+ "profiling",
+ "wasm-bindgen",
+ "web-sys",
+ "winit",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "emath"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74fbbf7501c430b89df62d102b6bfa02162faaf3e155512c677c9d20f5708d1"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -2788,6 +3403,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2810,6 +3452,34 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "epaint"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b452e348c2758115288802ca25f86ee286ce2cfae6643711ce116662311310"
+dependencies = [
+ "ahash",
+ "bytemuck",
+ "ecolor",
+ "emath",
+ "epaint_default_fonts",
+ "font-types",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "profiling",
+ "self_cell",
+ "skrifa",
+ "smallvec",
+ "vello_cpu",
+]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.34.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1644e25dbe3d663fd9c2a4181772c64b23361e377e550c10422ecc3a7de1c3c2"
 
 [[package]]
 name = "equator"
@@ -2846,6 +3516,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "esaxx-rs"
@@ -2982,6 +3658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fearless_simd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb2907d1f08b2b316b9223ced5b0e89d87028ba8deae9764741dba8ff7f3903"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3040,6 +3725,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "foreign-types"
@@ -3184,6 +3878,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3474,6 +4181,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3534,8 +4252,8 @@ checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
 dependencies = [
  "crossbeam-channel",
  "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "once_cell",
  "thiserror 2.0.18",
  "windows-sys 0.59.0",
@@ -3556,6 +4274,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg_aliases",
+ "cgl",
+ "dispatch2",
+ "glutin_egl_sys",
+ "glutin_glx_sys",
+ "glutin_wgl_sys",
+ "libloading 0.8.9",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "once_cell",
+ "raw-window-handle 0.6.2",
+ "wayland-sys",
+ "windows-sys 0.52.0",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin-winit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
+dependencies = [
+ "cfg_aliases",
+ "glutin",
+ "raw-window-handle 0.6.2",
+ "winit",
+]
+
+[[package]]
+name = "glutin_egl_sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
+dependencies = [
+ "gl_generator",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "glutin_glx_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
+dependencies = [
+ "gl_generator",
+ "x11-dl",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3564,6 +4360,40 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.11.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3731,6 +4561,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "hf-hub"
@@ -3922,7 +4758,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -4383,6 +5219,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,6 +5245,17 @@ dependencies = [
  "html5ever",
  "indexmap 2.13.1",
  "selectors",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
 ]
 
 [[package]]
@@ -5123,7 +5987,10 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -5181,6 +6048,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5358,7 +6231,7 @@ dependencies = [
  "manganis-core",
  "manganis-macro",
  "ndk-context",
- "objc2",
+ "objc2 0.6.4",
  "thiserror 2.0.18",
 ]
 
@@ -5617,10 +6490,10 @@ dependencies = [
  "gtk",
  "keyboard-types",
  "libxdo",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "thiserror 2.0.18",
@@ -5638,6 +6511,32 @@ name = "murmurhash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap 2.13.1",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
+]
 
 [[package]]
 name = "native-tls"
@@ -5727,6 +6626,12 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -5876,6 +6781,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5887,15 +6808,68 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5906,7 +6880,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -5916,7 +6890,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.0",
+ "dispatch2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5936,14 +6937,131 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "dispatch",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core 0.2.2",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
 ]
 
 [[package]]
@@ -5953,9 +7071,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5965,11 +7107,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -6101,12 +7243,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "orbclient"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a570f6bca41d29acb2139229a7c873ec99bc9a313bd10804081d89bfac8ff329"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -6131,6 +7293,15 @@ dependencies = [
  "hmac-sha256",
  "lzma-rust2",
  "ureq 3.3.0",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -6191,7 +7362,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -6236,6 +7407,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6274,7 +7458,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
@@ -6295,6 +7479,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
  "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -6348,6 +7543,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6359,6 +7564,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6398,6 +7616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.2",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6424,10 +7651,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -6453,6 +7697,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6505,6 +7763,12 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -6631,7 +7895,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -6686,6 +7950,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quinn"
@@ -6939,6 +8213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7007,6 +8287,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7044,10 +8336,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -7124,6 +8444,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,15 +8503,15 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "libc",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "pollster",
  "raw-window-handle 0.6.2",
@@ -7473,6 +8799,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sapphire-journal-gui"
+version = "0.0.0"
+dependencies = [
+ "eframe",
+ "egui",
+ "git2",
+ "sapphire-journal-core",
+ "serde",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "uuid",
+]
+
+[[package]]
 name = "sapphire-retrieve"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7588,6 +8928,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7627,6 +8980,12 @@ dependencies = [
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -7919,6 +9278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "skrifa"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7970,6 +9339,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smithay-client-toolkit"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
+dependencies = [
+ "bitflags 2.11.0",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.11.0",
+ "calloop 0.14.4",
+ "calloop-wayland-source 0.4.1",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smithay-clipboard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71704c03f739f7745053bde45fa203a46c58d25bc5c4efba1d9a60e9dba81226"
+dependencies = [
+ "libc",
+ "smithay-client-toolkit 0.20.0",
+ "wayland-backend",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7993,7 +9434,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8005,7 +9446,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8056,6 +9497,15 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -8135,6 +9585,12 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "string_cache"
@@ -8320,7 +9776,7 @@ dependencies = [
  "census",
  "crc32fast",
  "crossbeam-channel",
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "fastdivide",
  "fnv",
  "fs4",
@@ -8372,7 +9828,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
 dependencies = [
- "downcast-rs",
+ "downcast-rs 2.0.2",
  "fastdivide",
  "itertools 0.14.0",
  "serde",
@@ -8458,7 +9914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "crossbeam-channel",
@@ -8474,9 +9930,9 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle 0.5.2",
@@ -8484,8 +9940,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -8535,6 +9991,15 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -8647,6 +10112,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -8931,6 +10421,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -9007,11 +10498,11 @@ dependencies = [
  "dirs 6.0.0",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "thiserror 2.0.18",
@@ -9023,6 +10514,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "tungstenite"
@@ -9053,10 +10550,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -9249,6 +10766,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vello_common"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd1a4c633ce09e7d713df1a6e036644a125e15e0c169cfb5180ddf5836ca04b"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "hashbrown 0.16.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0162bfe48aabf6a9fdcd401b628c7d9f260c2cbabb343c70a65feba6f7849edc"
+dependencies = [
+ "bytemuck",
+ "hashbrown 0.16.1",
+ "vello_common",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9434,6 +10977,141 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs 1.2.1",
+ "rustix 1.1.4",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.11.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9463,8 +11141,8 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "url",
  "web-sys",
 ]
@@ -9548,8 +11226,8 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -9572,8 +11250,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9581,6 +11259,184 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap 2.13.1",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.11.0",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle 0.6.2",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle 0.6.2",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"
@@ -9619,11 +11475,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -9632,7 +11500,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -9649,14 +11526,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -9699,8 +11600,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9874,6 +11785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -10066,6 +11986,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
+dependencies = [
+ "ahash",
+ "android-activity",
+ "atomic-waker",
+ "bitflags 2.11.0",
+ "block2 0.5.1",
+ "bytemuck",
+ "calloop 0.13.0",
+ "cfg_aliases",
+ "concurrent-queue",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "libc",
+ "memmap2",
+ "ndk",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
+ "orbclient",
+ "percent-encoding",
+ "pin-project",
+ "raw-window-handle 0.6.2",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.44",
+ "sctk-adwaita",
+ "smithay-client-toolkit 0.19.2",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "web-sys",
+ "web-time",
+ "windows-sys 0.52.0",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10193,7 +12165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs 6.0.0",
@@ -10207,11 +12179,11 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
- "objc2-ui-kit",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
  "objc2-web-kit",
  "once_cell",
  "percent-encoding",
@@ -10224,8 +12196,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
 ]
 
@@ -10265,7 +12237,11 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
+ "libc",
+ "libloading 0.8.9",
+ "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
 ]
@@ -10277,10 +12253,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.11.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xxhash-rust"
@@ -10315,6 +12316,103 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.1",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6998de05217a084b7578728a9443d04ea4cd80f2a0839b8d78770b76ccd45863"
+dependencies = [
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10da05367f3a7b7553c8cdf8fa91aee6b64afebe32b51c95177957efc47ca3a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.1",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8067892e940ed1727dea64690378601603b31d62dfde019a5335fbb7c0e0ed9"
+dependencies = [
+ "quick-xml",
+ "serde",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -10453,4 +12551,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.1",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 1.0.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8870,6 +8870,7 @@ dependencies = [
 name = "sapphire-journal-gui"
 version = "0.0.0"
 dependencies = [
+ "chrono",
  "eframe",
  "egui",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "sapphire-journal",
     "sapphire-journal-core",
     "sapphire-journal-dioxus",
+    "sapphire-journal-gui",
 ]
 resolver = "3"
 

--- a/sapphire-journal-gui/Cargo.toml
+++ b/sapphire-journal-gui/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.1" }
 eframe = "0.34"
 egui = "0.34"
+rfd = "0.15"
 git2 = { version = "0.20", default-features = false }
 uuid = { version = "1", features = ["v4", "serde"] }
 serde = { workspace = true }

--- a/sapphire-journal-gui/Cargo.toml
+++ b/sapphire-journal-gui/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "sapphire-journal-gui"
+version = "0.0.0"
+authors = ["fluo10 <fluo10.dev@fireturtle.net>"]
+edition.workspace = true
+description.workspace = true
+license = "GPL-3.0-or-later"
+repository.workspace = true
+
+[dependencies]
+sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.1" }
+eframe = "0.34"
+egui = "0.34"
+git2 = { version = "0.20", default-features = false }
+uuid = { version = "1", features = ["v4", "serde"] }
+serde = { workspace = true }
+toml = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }

--- a/sapphire-journal-gui/Cargo.toml
+++ b/sapphire-journal-gui/Cargo.toml
@@ -11,9 +11,11 @@ repository.workspace = true
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.1" }
 eframe = "0.34"
 egui = "0.34"
+egui_extras = { version = "0.34", features = ["svg"] }
 rfd = "0.15"
 git2 = { version = "0.20", default-features = false }
 uuid = { version = "1", features = ["v4", "serde"] }
+grain-id = { version = "0.14" }
 serde = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }

--- a/sapphire-journal-gui/Cargo.toml
+++ b/sapphire-journal-gui/Cargo.toml
@@ -17,3 +17,4 @@ uuid = { version = "1", features = ["v4", "serde"] }
 serde = { workspace = true }
 toml = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+chrono = { workspace = true }

--- a/sapphire-journal-gui/assets/fonts/LICENSE-NotoSansJP
+++ b/sapphire-journal-gui/assets/fonts/LICENSE-NotoSansJP
@@ -1,0 +1,92 @@
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/sapphire-journal-gui/assets/icons/LICENSE-Lucide
+++ b/sapphire-journal-gui/assets/icons/LICENSE-Lucide
@@ -1,0 +1,43 @@
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, corner-up-left, corner-up-right, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sapphire-journal-gui/assets/icons/alarm-clock.svg
+++ b/sapphire-journal-gui/assets/icons/alarm-clock.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="13" r="8" />
+  <path d="M12 9v4l2 2" />
+  <path d="M5 3 2 6" />
+  <path d="m22 6-3-3" />
+  <path d="M6.38 18.7 4 21" />
+  <path d="M17.64 18.67 20 21" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/archive.svg
+++ b/sapphire-journal-gui/assets/icons/archive.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <rect width="20" height="5" x="2" y="3" rx="1" />
+  <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
+  <path d="M10 12h4" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/arrow-left.svg
+++ b/sapphire-journal-gui/assets/icons/arrow-left.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m12 19-7-7 7-7" />
+  <path d="M19 12H5" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/calendar-check.svg
+++ b/sapphire-journal-gui/assets/icons/calendar-check.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 2v4" />
+  <path d="M16 2v4" />
+  <rect width="18" height="18" x="3" y="4" rx="2" />
+  <path d="M3 10h18" />
+  <path d="m9 16 2 2 4-4" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/calendar.svg
+++ b/sapphire-journal-gui/assets/icons/calendar.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M8 2v4" />
+  <path d="M16 2v4" />
+  <rect width="18" height="18" x="3" y="4" rx="2" />
+  <path d="M3 10h18" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/chevron-down.svg
+++ b/sapphire-journal-gui/assets/icons/chevron-down.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m6 9 6 6 6-6" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/chevron-right.svg
+++ b/sapphire-journal-gui/assets/icons/chevron-right.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m9 18 6-6-6-6" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/circle-check.svg
+++ b/sapphire-journal-gui/assets/icons/circle-check.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="m9 12 2 2 4-4" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/circle-x.svg
+++ b/sapphire-journal-gui/assets/icons/circle-x.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="m15 9-6 6" />
+  <path d="m9 9 6 6" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/circle.svg
+++ b/sapphire-journal-gui/assets/icons/circle.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/clock.svg
+++ b/sapphire-journal-gui/assets/icons/clock.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M12 6v6l4 2" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/file-text.svg
+++ b/sapphire-journal-gui/assets/icons/file-text.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z" />
+  <path d="M14 2v5a1 1 0 0 0 1 1h5" />
+  <path d="M10 9H8" />
+  <path d="M16 13H8" />
+  <path d="M16 17H8" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/folder-tree.svg
+++ b/sapphire-journal-gui/assets/icons/folder-tree.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 10a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1h-2.5a1 1 0 0 1-.8-.4l-.9-1.2A1 1 0 0 0 15 3h-2a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z" />
+  <path d="M20 21a1 1 0 0 0 1-1v-3a1 1 0 0 0-1-1h-2.9a1 1 0 0 1-.88-.55l-.42-.85a1 1 0 0 0-.92-.6H13a1 1 0 0 0-1 1v5a1 1 0 0 0 1 1Z" />
+  <path d="M3 5a2 2 0 0 0 2 2h3" />
+  <path d="M3 3v13a2 2 0 0 0 2 2h3" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/funnel.svg
+++ b/sapphire-journal-gui/assets/icons/funnel.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 20a1 1 0 0 0 .553.895l2 1A1 1 0 0 0 14 21v-7a2 2 0 0 1 .517-1.341L21.74 4.67A1 1 0 0 0 21 3H3a1 1 0 0 0-.742 1.67l7.225 7.989A2 2 0 0 1 10 14z" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/list.svg
+++ b/sapphire-journal-gui/assets/icons/list.svg
@@ -1,0 +1,18 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 5h.01" />
+  <path d="M3 12h.01" />
+  <path d="M3 19h.01" />
+  <path d="M8 5h13" />
+  <path d="M8 12h13" />
+  <path d="M8 19h13" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/pencil-line.svg
+++ b/sapphire-journal-gui/assets/icons/pencil-line.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13 21h8" />
+  <path d="m15 5 4 4" />
+  <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/plus.svg
+++ b/sapphire-journal-gui/assets/icons/plus.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M5 12h14" />
+  <path d="M12 5v14" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/refresh-cw.svg
+++ b/sapphire-journal-gui/assets/icons/refresh-cw.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8" />
+  <path d="M21 3v5h-5" />
+  <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16" />
+  <path d="M8 16H3v5" />
+</svg>

--- a/sapphire-journal-gui/assets/icons/trash-2.svg
+++ b/sapphire-journal-gui/assets/icons/trash-2.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="#ffffff"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M10 11v6" />
+  <path d="M14 11v6" />
+  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+  <path d="M3 6h18" />
+  <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+</svg>

--- a/sapphire-journal-gui/src/app.rs
+++ b/sapphire-journal-gui/src/app.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use eframe::egui;
+use sapphire_journal_core::entry::EntryHeader;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -69,9 +70,86 @@ pub struct App {
     pub registry: JournalRegistry,
     pub dialog: Option<DialogState>,
     pub error_msg: Option<String>,
+    pub home: Option<HomeState>,
     pub runtime: Arc<tokio::runtime::Runtime>,
     pub event_tx: mpsc::UnboundedSender<AppEvent>,
     pub event_rx: mpsc::UnboundedReceiver<AppEvent>,
+}
+
+/// State for the journal-home screen (sidebar + editor).
+///
+/// Created when entering `AppState::Home` for a given journal and cleared
+/// when going back to the list.  Holds both transient UI state (filters,
+/// selection, form fields) and the loaded entry headers shown in the sidebar.
+pub struct HomeState {
+    pub journal_id: Uuid,
+    pub journal_root: PathBuf,
+    pub journal_name: String,
+
+    /// Cached headers for the entry sidebar; refreshed when `needs_reload` is set.
+    pub entries: Vec<EntryHeader>,
+    pub entries_error: Option<String>,
+    pub needs_reload: bool,
+
+    /// Currently-selected entry, if any.
+    pub selected_path: Option<PathBuf>,
+    pub editor: Option<EditorState>,
+
+    // ── Sidebar filter / sort state ─────────────────────────────────────────
+    pub filter_text: String,
+    /// Period preset (empty = all). One of "" | "today" | "yesterday" | ...
+    pub period: String,
+    /// Sort field. One of "updated_at" | "created_at" | "title" | "id"
+    /// | "task_due" | "event_start".
+    pub sort_by: String,
+    /// "asc" | "desc".
+    pub sort_order: String,
+
+    pub confirm_delete_entry: bool,
+    pub error_msg: Option<String>,
+    pub info_msg: Option<String>,
+}
+
+impl HomeState {
+    pub fn new(entry: RegistryEntry) -> Self {
+        Self {
+            journal_id: entry.id,
+            journal_root: entry.storage_path,
+            journal_name: entry.name,
+            entries: Vec::new(),
+            entries_error: None,
+            needs_reload: true,
+            selected_path: None,
+            editor: None,
+            filter_text: String::new(),
+            period: String::new(),
+            sort_by: "updated_at".to_string(),
+            sort_order: "desc".to_string(),
+            confirm_delete_entry: false,
+            error_msg: None,
+            info_msg: None,
+        }
+    }
+}
+
+/// Form fields for the entry currently being edited in the main panel.
+///
+/// The path of the entry being edited lives in `HomeState::selected_path` so
+/// that selection-aware UI (e.g. the sidebar's active-row highlight) and the
+/// editor stay in sync.
+pub struct EditorState {
+    pub id: String,
+    pub title: String,
+    /// Comma-separated tag input.
+    pub tags: String,
+    pub body: String,
+    pub has_task: bool,
+    pub task_status: String,
+    /// `YYYY-MM-DD` (empty = no due date).
+    pub task_due: String,
+    pub has_event: bool,
+    pub event_start: String,
+    pub event_end: String,
 }
 
 impl App {
@@ -88,6 +166,7 @@ impl App {
             registry: JournalRegistry::load().unwrap_or_default(),
             dialog: None,
             error_msg: None,
+            home: None,
             runtime,
             event_tx,
             event_rx,

--- a/sapphire-journal-gui/src/app.rs
+++ b/sapphire-journal-gui/src/app.rs
@@ -4,8 +4,9 @@ use std::sync::{Arc, Mutex};
 
 use eframe::egui;
 use grain_id::GrainId;
-use sapphire_journal_core::entry::EntryHeader;
+use sapphire_journal_core::{JournalState, entry::EntryHeader, user_config::UserConfig};
 use tokio::sync::mpsc;
+use tokio::time;
 use uuid::Uuid;
 
 use crate::registry::{JournalRegistry, RegistryEntry};
@@ -66,6 +67,9 @@ pub enum AppEvent {
         storage_path: PathBuf,
         error: String,
     },
+    /// Sent by the periodic-sync task after a successful sync so the UI can
+    /// reload entries that may have been added or modified by `git pull`.
+    EntriesNeedReload,
 }
 
 pub struct App {
@@ -78,6 +82,10 @@ pub struct App {
     /// When the user went to the journal-list screen from an open journal,
     /// this records that journal so the list can offer a "back" button.
     pub previous_journal_id: Option<Uuid>,
+    /// Currently-open journal's [`JournalState`] (cache DB + retrieve DB +
+    /// optional git-sync backend).  `None` when no journal is open.  Shared
+    /// with the background-sync tokio task, hence `Arc<Mutex<…>>`.
+    pub journal_state: Arc<Mutex<Option<JournalState>>>,
     pub runtime: Arc<tokio::runtime::Runtime>,
     pub event_tx: mpsc::UnboundedSender<AppEvent>,
     pub event_rx: mpsc::UnboundedReceiver<AppEvent>,
@@ -181,7 +189,7 @@ pub struct EditorState {
 }
 
 impl App {
-    pub fn new() -> Self {
+    pub fn new(egui_ctx: egui::Context) -> Self {
         let runtime = Arc::new(
             tokio::runtime::Builder::new_multi_thread()
                 .enable_all()
@@ -206,6 +214,49 @@ impl App {
             None => (AppState::List, None),
         };
 
+        let journal_state: Arc<Mutex<Option<JournalState>>> = Arc::new(Mutex::new(None));
+
+        // Periodic background sync: cache + retrieve refresh + git pull/push,
+        // mirroring the cadence used by the MCP server.  Skips ticks when no
+        // journal is open.
+        if let Some(interval) = UserConfig::load().ok().and_then(|c| c.sync_interval()) {
+            let state_arc = Arc::clone(&journal_state);
+            let tx = event_tx.clone();
+            let ctx = egui_ctx.clone();
+            runtime.spawn(async move {
+                let mut ticker = time::interval(interval);
+                ticker.tick().await; // skip the immediate first tick
+                loop {
+                    ticker.tick().await;
+                    let did_sync = {
+                        let guard = state_arc.lock().unwrap();
+                        match guard.as_ref() {
+                            Some(state) => {
+                                if let Err(e) = state.sync() {
+                                    let _ = tx.send(AppEvent::Error(format!(
+                                        "Periodic cache sync failed: {e}"
+                                    )));
+                                }
+                                if let Err(e) = state.git_sync() {
+                                    let _ = tx.send(AppEvent::Error(format!(
+                                        "Periodic git sync failed: {e}"
+                                    )));
+                                }
+                                true
+                            }
+                            None => false,
+                        }
+                    };
+                    if did_sync {
+                        let _ = tx.send(AppEvent::EntriesNeedReload);
+                    }
+                    // Wake the UI thread so the event is processed promptly
+                    // even if the window has no pending input.
+                    ctx.request_repaint();
+                }
+            });
+        }
+
         Self {
             screen,
             registry,
@@ -214,6 +265,7 @@ impl App {
             error_msg: None,
             home,
             previous_journal_id: None,
+            journal_state,
             runtime,
             event_tx,
             event_rx,
@@ -260,6 +312,11 @@ impl App {
                     let _ = std::fs::remove_dir_all(&storage_path);
                     self.error_msg = Some(error);
                     self.dialog = None;
+                }
+                AppEvent::EntriesNeedReload => {
+                    if let Some(home) = self.home.as_mut() {
+                        home.needs_reload = true;
+                    }
                 }
             }
         }

--- a/sapphire-journal-gui/src/app.rs
+++ b/sapphire-journal-gui/src/app.rs
@@ -1,13 +1,16 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use eframe::egui;
+use grain_id::GrainId;
 use sapphire_journal_core::entry::EntryHeader;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::registry::{JournalRegistry, RegistryEntry};
 use crate::screens;
+use crate::settings::Settings;
 
 #[derive(Clone, PartialEq)]
 pub enum AppState {
@@ -68,9 +71,13 @@ pub enum AppEvent {
 pub struct App {
     pub screen: AppState,
     pub registry: JournalRegistry,
+    pub settings: Settings,
     pub dialog: Option<DialogState>,
     pub error_msg: Option<String>,
     pub home: Option<HomeState>,
+    /// When the user went to the journal-list screen from an open journal,
+    /// this records that journal so the list can offer a "back" button.
+    pub previous_journal_id: Option<Uuid>,
     pub runtime: Arc<tokio::runtime::Runtime>,
     pub event_tx: mpsc::UnboundedSender<AppEvent>,
     pub event_rx: mpsc::UnboundedReceiver<AppEvent>,
@@ -94,6 +101,15 @@ pub struct HomeState {
     /// Currently-selected entry, if any.
     pub selected_path: Option<PathBuf>,
     pub editor: Option<EditorState>,
+
+    /// Hierarchical (tree) or flat (list) display of entries.
+    pub view_mode: ViewMode,
+    /// IDs of tree nodes whose children are currently hidden.  Default open
+    /// (a node not in this set is expanded).
+    pub collapsed: HashSet<GrainId>,
+    /// Whether the period / sort / order pickers are visible. Toggled by
+    /// the funnel icon in the sidebar toolbar.  Search input stays visible.
+    pub show_filters: bool,
 
     // ── Sidebar filter / sort state ─────────────────────────────────────────
     pub filter_text: String,
@@ -121,6 +137,9 @@ impl HomeState {
             needs_reload: true,
             selected_path: None,
             editor: None,
+            view_mode: ViewMode::Tree,
+            collapsed: HashSet::new(),
+            show_filters: false,
             filter_text: String::new(),
             period: String::new(),
             sort_by: "updated_at".to_string(),
@@ -130,6 +149,15 @@ impl HomeState {
             info_msg: None,
         }
     }
+}
+
+/// How the entry sidebar should display entries.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ViewMode {
+    /// Hierarchical view following `parent_id` relationships.
+    Tree,
+    /// Flat list, ignoring hierarchy.
+    List,
 }
 
 /// Form fields for the entry currently being edited in the main panel.
@@ -161,15 +189,46 @@ impl App {
                 .expect("failed to start tokio runtime"),
         );
         let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let registry = JournalRegistry::load().unwrap_or_default();
+        let settings = Settings::load().unwrap_or_default();
+
+        // Resume into the previously-open journal when possible; otherwise
+        // fall back to the list screen as a first-run / picker fallback.
+        let (screen, home) = match settings
+            .last_opened_journal_id
+            .and_then(|id| registry.journals.iter().find(|e| e.id == id).cloned())
+            .filter(|entry| entry.storage_path.join(".sapphire-journal").is_dir())
+        {
+            Some(entry) => {
+                let id = entry.id;
+                (AppState::Home { journal_id: id }, Some(HomeState::new(entry)))
+            }
+            None => (AppState::List, None),
+        };
+
         Self {
-            screen: AppState::List,
-            registry: JournalRegistry::load().unwrap_or_default(),
+            screen,
+            registry,
+            settings,
             dialog: None,
             error_msg: None,
-            home: None,
+            home,
+            previous_journal_id: None,
             runtime,
             event_tx,
             event_rx,
+        }
+    }
+
+    /// Update `settings.last_opened_journal_id` and persist immediately.
+    /// Errors fall into `self.error_msg`.
+    pub fn remember_last_opened(&mut self, id: Option<Uuid>) {
+        if self.settings.last_opened_journal_id == id {
+            return;
+        }
+        self.settings.last_opened_journal_id = id;
+        if let Err(e) = self.settings.save() {
+            self.error_msg = Some(format!("Failed to save settings: {e}"));
         }
     }
 

--- a/sapphire-journal-gui/src/app.rs
+++ b/sapphire-journal-gui/src/app.rs
@@ -1,0 +1,151 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use eframe::egui;
+use tokio::sync::mpsc;
+use uuid::Uuid;
+
+use crate::registry::{JournalRegistry, RegistryEntry};
+use crate::screens;
+
+#[derive(Clone, PartialEq)]
+pub enum AppState {
+    List,
+    Home { journal_id: Uuid },
+}
+
+pub enum DialogState {
+    NewJournal(NewJournalState),
+    Clone(CloneState),
+    ConfirmDelete(ConfirmDeleteState),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DialogKind {
+    NewJournal,
+    Clone,
+    ConfirmDelete,
+}
+
+impl DialogState {
+    pub fn kind(&self) -> DialogKind {
+        match self {
+            DialogState::NewJournal(_) => DialogKind::NewJournal,
+            DialogState::Clone(_) => DialogKind::Clone,
+            DialogState::ConfirmDelete(_) => DialogKind::ConfirmDelete,
+        }
+    }
+}
+
+pub struct NewJournalState {
+    pub name: String,
+    pub in_progress: bool,
+}
+
+pub struct CloneState {
+    pub name: String,
+    pub url: String,
+    pub progress: Arc<Mutex<Option<f32>>>,
+}
+
+pub struct ConfirmDeleteState {
+    pub entry: RegistryEntry,
+    pub typed: String,
+    pub in_progress: bool,
+}
+
+pub enum AppEvent {
+    JournalAdded(RegistryEntry),
+    JournalRemoved(Uuid),
+    Error(String),
+    CleanupAndError {
+        storage_path: PathBuf,
+        error: String,
+    },
+}
+
+pub struct App {
+    pub screen: AppState,
+    pub registry: JournalRegistry,
+    pub dialog: Option<DialogState>,
+    pub error_msg: Option<String>,
+    pub runtime: Arc<tokio::runtime::Runtime>,
+    pub event_tx: mpsc::UnboundedSender<AppEvent>,
+    pub event_rx: mpsc::UnboundedReceiver<AppEvent>,
+}
+
+impl App {
+    pub fn new() -> Self {
+        let runtime = Arc::new(
+            tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("failed to start tokio runtime"),
+        );
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        Self {
+            screen: AppState::List,
+            registry: JournalRegistry::load().unwrap_or_default(),
+            dialog: None,
+            error_msg: None,
+            runtime,
+            event_tx,
+            event_rx,
+        }
+    }
+
+    fn handle_events(&mut self) {
+        while let Ok(ev) = self.event_rx.try_recv() {
+            match ev {
+                AppEvent::JournalAdded(entry) => {
+                    self.registry.add(entry);
+                    if let Err(e) = self.registry.save() {
+                        self.error_msg = Some(e.to_string());
+                    }
+                    self.dialog = None;
+                }
+                AppEvent::JournalRemoved(id) => {
+                    self.registry.remove_by_id(id);
+                    if let Err(e) = self.registry.save() {
+                        self.error_msg = Some(e.to_string());
+                    }
+                    self.dialog = None;
+                }
+                AppEvent::Error(msg) => {
+                    self.error_msg = Some(msg);
+                    self.dialog = None;
+                }
+                AppEvent::CleanupAndError {
+                    storage_path,
+                    error,
+                } => {
+                    let _ = std::fs::remove_dir_all(&storage_path);
+                    self.error_msg = Some(error);
+                    self.dialog = None;
+                }
+            }
+        }
+    }
+}
+
+impl eframe::App for App {
+    fn logic(&mut self, _ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        self.handle_events();
+    }
+
+    fn ui(&mut self, ui: &mut egui::Ui, _frame: &mut eframe::Frame) {
+        // While a clone is in progress we need the UI to keep repainting so the
+        // progress bar advances even when no input events arrive.
+        if let Some(DialogState::Clone(state)) = &self.dialog {
+            if state.progress.lock().unwrap().is_some() {
+                ui.ctx()
+                    .request_repaint_after(std::time::Duration::from_millis(100));
+            }
+        }
+
+        match self.screen.clone() {
+            AppState::List => screens::journal_list::show(self, ui),
+            AppState::Home { journal_id } => screens::journal_home::show(self, ui, journal_id),
+        }
+    }
+}

--- a/sapphire-journal-gui/src/app.rs
+++ b/sapphire-journal-gui/src/app.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use crate::registry::{JournalRegistry, RegistryEntry};
 use crate::screens;
+use crate::screens::settings_panel::SettingsPanelState;
 use crate::settings::Settings;
 
 #[derive(Clone, PartialEq)]
@@ -86,6 +87,9 @@ pub struct App {
     /// optional git-sync backend).  `None` when no journal is open.  Shared
     /// with the background-sync tokio task, hence `Arc<Mutex<…>>`.
     pub journal_state: Arc<Mutex<Option<JournalState>>>,
+    /// When `Some`, the Settings window is shown on top of the current
+    /// screen.  Opened from the journal switcher menu.
+    pub settings_panel: Option<SettingsPanelState>,
     pub runtime: Arc<tokio::runtime::Runtime>,
     pub event_tx: mpsc::UnboundedSender<AppEvent>,
     pub event_rx: mpsc::UnboundedReceiver<AppEvent>,
@@ -266,6 +270,7 @@ impl App {
             home,
             previous_journal_id: None,
             journal_state,
+            settings_panel: None,
             runtime,
             event_tx,
             event_rx,

--- a/sapphire-journal-gui/src/dialogs/clone.rs
+++ b/sapphire-journal-gui/src/dialogs/clone.rs
@@ -1,0 +1,162 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use eframe::egui;
+use uuid::Uuid;
+
+use crate::app::{App, AppEvent, DialogState};
+use crate::registry::{JournalRegistry, RegistryEntry};
+use sapphire_journal_core::journal::Journal;
+
+pub fn show(app: &mut App, ctx: &egui::Context) {
+    let mut close = false;
+    let mut submit = false;
+
+    let DialogState::Clone(state) = app.dialog.as_mut().unwrap() else {
+        return;
+    };
+
+    let progress_arc = Arc::clone(&state.progress);
+    let current_progress = *progress_arc.lock().unwrap();
+    let in_progress = current_progress.is_some();
+
+    let mut open = true;
+    egui::Window::new("Clone Journal")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.set_min_width(420.0);
+
+            ui.label("Journal Name");
+            let name_resp = ui.add(
+                egui::TextEdit::singleline(&mut state.name)
+                    .hint_text("e.g. Work Journal")
+                    .desired_width(f32::INFINITY),
+            );
+            if !in_progress && !name_resp.has_focus() && state.name.is_empty() {
+                name_resp.request_focus();
+            }
+
+            ui.add_space(6.0);
+
+            ui.label("Remote URL (HTTPS)");
+            ui.add(
+                egui::TextEdit::singleline(&mut state.url)
+                    .hint_text("https://github.com/you/journal.git")
+                    .desired_width(f32::INFINITY),
+            );
+
+            if let Some(progress) = current_progress {
+                ui.add_space(8.0);
+                ui.add(egui::ProgressBar::new(progress).show_percentage());
+                ui.small(format!("Cloning… {:.0}%", progress * 100.0));
+            }
+
+            ui.add_space(8.0);
+
+            let name_trimmed = state.name.trim().to_string();
+            let url_trimmed = state.url.trim().to_string();
+            let can_clone = !name_trimmed.is_empty() && !url_trimmed.is_empty() && !in_progress;
+
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let label = if in_progress { "Cloning…" } else { "Clone" };
+                    if ui
+                        .add_enabled(can_clone, egui::Button::new(label))
+                        .clicked()
+                    {
+                        submit = true;
+                    }
+                    if ui
+                        .add_enabled(!in_progress, egui::Button::new("Cancel"))
+                        .clicked()
+                    {
+                        close = true;
+                    }
+                });
+            });
+        });
+
+    if !open && !in_progress {
+        close = true;
+    }
+
+    if submit {
+        let name = state.name.trim().to_string();
+        let url = state.url.trim().to_string();
+        let storage_path = JournalRegistry::journals_dir().join(Uuid::new_v4().to_string());
+        let progress = Arc::clone(&state.progress);
+        *progress.lock().unwrap() = Some(0.0);
+
+        let tx = app.event_tx.clone();
+        let storage_clone = storage_path.clone();
+        let progress_clone = Arc::clone(&progress);
+
+        app.runtime.spawn(async move {
+            let storage_for_blocking = storage_clone.clone();
+            let progress_for_blocking = Arc::clone(&progress_clone);
+            let result = tokio::task::spawn_blocking(move || {
+                let mut callbacks = git2::RemoteCallbacks::new();
+                let progress_cb = Arc::clone(&progress_for_blocking);
+                callbacks.transfer_progress(move |stats| {
+                    let total = stats.total_objects().max(1) as f32;
+                    let done = stats.received_objects() as f32;
+                    *progress_cb.lock().unwrap() = Some(done / total);
+                    true
+                });
+                let mut fetch_opts = git2::FetchOptions::new();
+                fetch_opts.remote_callbacks(callbacks);
+                git2::build::RepoBuilder::new()
+                    .fetch_options(fetch_opts)
+                    .clone(&url, &storage_for_blocking)
+            })
+            .await;
+
+            // Reset the progress so the dialog leaves "in progress" state.
+            *progress_clone.lock().unwrap() = None;
+
+            match result {
+                Ok(Ok(_repo)) => match validate_journal(&storage_clone) {
+                    Ok(journal_id) => {
+                        let _ = tx.send(AppEvent::JournalAdded(RegistryEntry {
+                            id: journal_id,
+                            name,
+                            storage_path: storage_clone,
+                        }));
+                    }
+                    Err(e) => {
+                        let _ = tx.send(AppEvent::CleanupAndError {
+                            storage_path: storage_clone,
+                            error: e,
+                        });
+                    }
+                },
+                Ok(Err(e)) => {
+                    let _ = tx.send(AppEvent::CleanupAndError {
+                        storage_path: storage_clone,
+                        error: e.to_string(),
+                    });
+                }
+                Err(e) => {
+                    let _ = tx.send(AppEvent::CleanupAndError {
+                        storage_path: storage_clone,
+                        error: e.to_string(),
+                    });
+                }
+            }
+        });
+    }
+
+    if close {
+        app.dialog = None;
+    }
+}
+
+fn validate_journal(storage_path: &PathBuf) -> Result<Uuid, String> {
+    let journal = Journal::from_root(storage_path.clone()).map_err(|_| {
+        "The cloned repository is not a sapphire journal (missing .sapphire-journal/)".to_string()
+    })?;
+    journal.journal_id().map_err(|e| e.to_string())
+}

--- a/sapphire-journal-gui/src/dialogs/confirm_delete.rs
+++ b/sapphire-journal-gui/src/dialogs/confirm_delete.rs
@@ -1,0 +1,102 @@
+use eframe::egui;
+
+use crate::app::{App, AppEvent, DialogState};
+
+pub fn show(app: &mut App, ctx: &egui::Context) {
+    let mut close = false;
+    let mut submit = false;
+
+    let DialogState::ConfirmDelete(state) = app.dialog.as_mut().unwrap() else {
+        return;
+    };
+
+    let expected = state.entry.name.clone();
+    let entry_id = state.entry.id;
+    let storage_path = state.entry.storage_path.clone();
+
+    let mut open = true;
+    egui::Window::new("Delete Journal")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.set_min_width(360.0);
+
+            ui.colored_label(
+                egui::Color32::LIGHT_RED,
+                "This will permanently delete the journal and all its entries.",
+            );
+            ui.label("This action cannot be undone.");
+            ui.add_space(8.0);
+
+            ui.horizontal_wrapped(|ui| {
+                ui.label("Type");
+                ui.strong(&expected);
+                ui.label("to confirm:");
+            });
+            let resp = ui.add(
+                egui::TextEdit::singleline(&mut state.typed)
+                    .hint_text(&expected)
+                    .desired_width(f32::INFINITY),
+            );
+            if !state.in_progress {
+                resp.request_focus();
+            }
+
+            let name_matches = state.typed.trim() == expected.as_str();
+            let can_delete = name_matches && !state.in_progress;
+
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let label = if state.in_progress {
+                        "Deleting…"
+                    } else {
+                        "Delete Journal"
+                    };
+                    if ui
+                        .add_enabled(can_delete, egui::Button::new(label))
+                        .clicked()
+                    {
+                        submit = true;
+                    }
+                    if ui
+                        .add_enabled(!state.in_progress, egui::Button::new("Cancel"))
+                        .clicked()
+                    {
+                        close = true;
+                    }
+                });
+            });
+        });
+
+    if !open && !state.in_progress {
+        close = true;
+    }
+
+    if submit {
+        state.in_progress = true;
+        let tx = app.event_tx.clone();
+        app.runtime.spawn(async move {
+            let storage = storage_path.clone();
+            let result =
+                tokio::task::spawn_blocking(move || std::fs::remove_dir_all(&storage)).await;
+            match result {
+                Ok(Ok(())) => {
+                    let _ = tx.send(AppEvent::JournalRemoved(entry_id));
+                }
+                Ok(Err(e)) => {
+                    let _ = tx.send(AppEvent::Error(e.to_string()));
+                }
+                Err(e) => {
+                    let _ = tx.send(AppEvent::Error(e.to_string()));
+                }
+            }
+        });
+    }
+
+    if close {
+        app.dialog = None;
+    }
+}

--- a/sapphire-journal-gui/src/dialogs/mod.rs
+++ b/sapphire-journal-gui/src/dialogs/mod.rs
@@ -1,0 +1,3 @@
+pub mod clone;
+pub mod confirm_delete;
+pub mod new_journal;

--- a/sapphire-journal-gui/src/dialogs/new_journal.rs
+++ b/sapphire-journal-gui/src/dialogs/new_journal.rs
@@ -1,0 +1,105 @@
+use eframe::egui;
+use uuid::Uuid;
+
+use crate::app::{App, AppEvent, DialogState};
+use crate::registry::{init_journal, JournalRegistry, RegistryEntry};
+
+pub fn show(app: &mut App, ctx: &egui::Context) {
+    let mut close = false;
+    let mut submit_name: Option<String> = None;
+
+    let DialogState::NewJournal(state) = app.dialog.as_mut().unwrap() else {
+        return;
+    };
+
+    let mut open = true;
+    egui::Window::new("New Journal")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.set_min_width(360.0);
+
+            ui.label("Journal Name");
+            let resp = ui.add(
+                egui::TextEdit::singleline(&mut state.name)
+                    .hint_text("e.g. My Journal")
+                    .desired_width(f32::INFINITY),
+            );
+            if !state.in_progress {
+                resp.request_focus();
+            }
+            let enter_pressed =
+                resp.lost_focus() && ui.input(|i| i.key_pressed(egui::Key::Enter));
+
+            ui.add_space(8.0);
+
+            let trimmed = state.name.trim().to_string();
+            let can_create = !trimmed.is_empty() && !state.in_progress;
+
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    let create_label = if state.in_progress {
+                        "Creating…"
+                    } else {
+                        "Create"
+                    };
+                    if ui
+                        .add_enabled(can_create, egui::Button::new(create_label))
+                        .clicked()
+                        || (enter_pressed && can_create)
+                    {
+                        submit_name = Some(trimmed.clone());
+                    }
+                    if ui
+                        .add_enabled(!state.in_progress, egui::Button::new("Cancel"))
+                        .clicked()
+                    {
+                        close = true;
+                    }
+                });
+            });
+        });
+
+    if !open && !state.in_progress {
+        close = true;
+    }
+
+    if let Some(name) = submit_name {
+        state.in_progress = true;
+        let storage_uuid = Uuid::new_v4();
+        let storage_path = JournalRegistry::journals_dir().join(storage_uuid.to_string());
+        let storage_path_clone = storage_path.clone();
+        let tx = app.event_tx.clone();
+        app.runtime.spawn(async move {
+            let result =
+                tokio::task::spawn_blocking(move || init_journal(&storage_path)).await;
+            match result {
+                Ok(Ok(journal_id)) => {
+                    let _ = tx.send(AppEvent::JournalAdded(RegistryEntry {
+                        id: journal_id,
+                        name,
+                        storage_path: storage_path_clone,
+                    }));
+                }
+                Ok(Err(e)) => {
+                    let _ = tx.send(AppEvent::CleanupAndError {
+                        storage_path: storage_path_clone,
+                        error: e.to_string(),
+                    });
+                }
+                Err(e) => {
+                    let _ = tx.send(AppEvent::CleanupAndError {
+                        storage_path: storage_path_clone,
+                        error: e.to_string(),
+                    });
+                }
+            }
+        });
+    }
+
+    if close {
+        app.dialog = None;
+    }
+}

--- a/sapphire-journal-gui/src/error.rs
+++ b/sapphire-journal-gui/src/error.rs
@@ -1,0 +1,46 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum AppError {
+    Io(std::io::Error),
+    Toml(String),
+    Git(git2::Error),
+    Domain(String),
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AppError::Io(e) => write!(f, "I/O error: {e}"),
+            AppError::Toml(e) => write!(f, "Config error: {e}"),
+            AppError::Git(e) => write!(f, "Git error: {e}"),
+            AppError::Domain(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(e: std::io::Error) -> Self {
+        AppError::Io(e)
+    }
+}
+
+impl From<toml::de::Error> for AppError {
+    fn from(e: toml::de::Error) -> Self {
+        AppError::Toml(e.to_string())
+    }
+}
+
+impl From<toml::ser::Error> for AppError {
+    fn from(e: toml::ser::Error) -> Self {
+        AppError::Toml(e.to_string())
+    }
+}
+
+impl From<git2::Error> for AppError {
+    fn from(e: git2::Error) -> Self {
+        AppError::Git(e)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, AppError>;

--- a/sapphire-journal-gui/src/fonts.rs
+++ b/sapphire-journal-gui/src/fonts.rs
@@ -1,0 +1,66 @@
+//! Font setup for the GUI.
+//!
+//! Currently this module loads a single bundled Japanese font (Noto Sans JP)
+//! and registers it as a fallback for the proportional and monospace
+//! families.  Latin text continues to be rendered by egui's built-in fonts;
+//! Noto Sans JP fills in CJK glyphs that would otherwise render as tofu.
+//!
+//! ## Future work
+//!
+//! The intent is to let the user pick a font (including OS-installed fonts,
+//! e.g. via `font-kit`) for accessibility — dyslexia-friendly fonts and
+//! similar.  The public API of this module is shaped to make that change
+//! additive:
+//!
+//! - [`install`] is the single entry point invoked from `main.rs`.
+//! - Internal helpers [`base_definitions`] and [`add_bundled_jp`] produce a
+//!   `FontDefinitions` step-by-step, so additional sources (OS, user-chosen
+//!   file path, settings) can be layered on top without touching callers.
+
+use std::sync::Arc;
+
+use eframe::egui;
+
+/// Bundled Japanese fallback font: Noto Sans JP Regular (SIL OFL 1.1).
+///
+/// See `assets/fonts/LICENSE-NotoSansJP` for the full license.
+const NOTO_SANS_JP: &[u8] =
+    include_bytes!("../assets/fonts/NotoSansJP-Regular.otf");
+
+const BUNDLED_JP_KEY: &str = "noto_sans_jp";
+
+/// Configure the global egui font set on `ctx`.
+///
+/// Call this once at startup from the eframe creation callback.
+pub fn install(ctx: &egui::Context) {
+    let mut fonts = base_definitions();
+    add_bundled_jp(&mut fonts);
+    ctx.set_fonts(fonts);
+}
+
+/// Start from egui's defaults so Latin text keeps its built-in fonts.
+fn base_definitions() -> egui::FontDefinitions {
+    egui::FontDefinitions::default()
+}
+
+/// Register the bundled Noto Sans JP face as a *fallback* for both font
+/// families.  Latin glyphs still resolve through egui's defaults first;
+/// CJK glyphs that the defaults lack fall through to Noto Sans JP.
+fn add_bundled_jp(fonts: &mut egui::FontDefinitions) {
+    fonts.font_data.insert(
+        BUNDLED_JP_KEY.to_owned(),
+        Arc::new(egui::FontData::from_static(NOTO_SANS_JP)),
+    );
+
+    fonts
+        .families
+        .entry(egui::FontFamily::Proportional)
+        .or_default()
+        .push(BUNDLED_JP_KEY.to_owned());
+
+    fonts
+        .families
+        .entry(egui::FontFamily::Monospace)
+        .or_default()
+        .push(BUNDLED_JP_KEY.to_owned());
+}

--- a/sapphire-journal-gui/src/icons.rs
+++ b/sapphire-journal-gui/src/icons.rs
@@ -1,0 +1,50 @@
+#![allow(dead_code)]
+
+//! Bundled SVG icons (Lucide, ISC license).
+//!
+//! All icons are embedded at compile time via [`egui::include_image!`] and
+//! decoded by `egui_extras`'s SVG loader (see `main.rs` for the loader
+//! installation).  Lucide SVGs use `stroke="currentColor"` so they tint via
+//! `egui::Image::tint`.
+
+use eframe::egui;
+
+use sapphire_journal_core::labels::EntryFlag;
+
+macro_rules! icon {
+    ($name:literal) => {
+        egui::include_image!(concat!("../assets/icons/", $name, ".svg"))
+    };
+}
+
+// ── Toolbar / chrome ───────────────────────────────────────────────────────
+
+pub fn arrow_left() -> egui::ImageSource<'static> { icon!("arrow-left") }
+pub fn chevron_down() -> egui::ImageSource<'static> { icon!("chevron-down") }
+pub fn chevron_right() -> egui::ImageSource<'static> { icon!("chevron-right") }
+pub fn funnel() -> egui::ImageSource<'static> { icon!("funnel") }
+pub fn list_view() -> egui::ImageSource<'static> { icon!("list") }
+pub fn tree_view() -> egui::ImageSource<'static> { icon!("folder-tree") }
+pub fn plus() -> egui::ImageSource<'static> { icon!("plus") }
+pub fn refresh() -> egui::ImageSource<'static> { icon!("refresh-cw") }
+pub fn trash() -> egui::ImageSource<'static> { icon!("trash-2") }
+
+// ── Entry flags ────────────────────────────────────────────────────────────
+
+/// SVG icon for an [`EntryFlag`].  Replaces the emoji-based glyph that used to
+/// render as tofu when no color emoji font was available.
+pub fn flag_icon(flag: EntryFlag) -> egui::ImageSource<'static> {
+    match flag {
+        EntryFlag::Overdue     => icon!("alarm-clock"),
+        EntryFlag::New         => icon!("plus"),
+        EntryFlag::Updated     => icon!("pencil-line"),
+        EntryFlag::Event       => icon!("calendar"),
+        EntryFlag::EventClosed => icon!("calendar-check"),
+        EntryFlag::Done        => icon!("circle-check"),
+        EntryFlag::Cancelled   => icon!("circle-x"),
+        EntryFlag::InProgress  => icon!("clock"),
+        EntryFlag::Archived    => icon!("archive"),
+        EntryFlag::Open        => icon!("circle"),
+        EntryFlag::Note        => icon!("file-text"),
+    }
+}

--- a/sapphire-journal-gui/src/main.rs
+++ b/sapphire-journal-gui/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> eframe::Result<()> {
         Box::new(|cc| {
             fonts::install(&cc.egui_ctx);
             egui_extras::install_image_loaders(&cc.egui_ctx);
-            Ok(Box::new(App::new()))
+            Ok(Box::new(App::new(cc.egui_ctx.clone())))
         }),
     )
 }

--- a/sapphire-journal-gui/src/main.rs
+++ b/sapphire-journal-gui/src/main.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use eframe::egui;
+
+mod app;
+mod dialogs;
+mod error;
+mod registry;
+mod screens;
+
+use app::App;
+
+fn main() -> eframe::Result<()> {
+    let options = eframe::NativeOptions {
+        viewport: egui::ViewportBuilder::default()
+            .with_inner_size([900.0, 600.0])
+            .with_min_inner_size([600.0, 400.0])
+            .with_title("Sapphire Journal"),
+        ..Default::default()
+    };
+
+    eframe::run_native(
+        "Sapphire Journal",
+        options,
+        Box::new(|_cc| Ok(Box::new(App::new()))),
+    )
+}

--- a/sapphire-journal-gui/src/main.rs
+++ b/sapphire-journal-gui/src/main.rs
@@ -5,6 +5,7 @@ use eframe::egui;
 mod app;
 mod dialogs;
 mod error;
+mod fonts;
 mod registry;
 mod screens;
 
@@ -22,6 +23,9 @@ fn main() -> eframe::Result<()> {
     eframe::run_native(
         "Sapphire Journal",
         options,
-        Box::new(|_cc| Ok(Box::new(App::new()))),
+        Box::new(|cc| {
+            fonts::install(&cc.egui_ctx);
+            Ok(Box::new(App::new()))
+        }),
     )
 }

--- a/sapphire-journal-gui/src/main.rs
+++ b/sapphire-journal-gui/src/main.rs
@@ -6,8 +6,10 @@ mod app;
 mod dialogs;
 mod error;
 mod fonts;
+mod icons;
 mod registry;
 mod screens;
+mod settings;
 
 use app::App;
 
@@ -25,6 +27,7 @@ fn main() -> eframe::Result<()> {
         options,
         Box::new(|cc| {
             fonts::install(&cc.egui_ctx);
+            egui_extras::install_image_loaders(&cc.egui_ctx);
             Ok(Box::new(App::new()))
         }),
     )

--- a/sapphire-journal-gui/src/registry.rs
+++ b/sapphire-journal-gui/src/registry.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{AppError, Result};
+
+/// One registered journal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegistryEntry {
+    /// Stable journal ID from `.sapphire-journal/config.toml [journal].id`.
+    pub id: Uuid,
+    /// User-visible display name.
+    pub name: String,
+    /// Absolute path to the journal's git repository root
+    /// (`~/.local/share/sapphire-journal/journals/<uuid>/`).
+    pub storage_path: PathBuf,
+}
+
+/// The list of all journals known to the GUI, persisted as TOML.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct JournalRegistry {
+    #[serde(default)]
+    pub journals: Vec<RegistryEntry>,
+}
+
+impl JournalRegistry {
+    /// `$XDG_DATA_HOME/sapphire-journal/`
+    pub fn data_dir() -> PathBuf {
+        xdg_data_home().join("sapphire-journal")
+    }
+
+    /// `$XDG_DATA_HOME/sapphire-journal/journals/`
+    pub fn journals_dir() -> PathBuf {
+        Self::data_dir().join("journals")
+    }
+
+    /// `$XDG_DATA_HOME/sapphire-journal/journals.toml`
+    pub fn registry_path() -> PathBuf {
+        Self::data_dir().join("journals.toml")
+    }
+
+    /// Load the registry from disk, returning an empty registry if the file does not exist.
+    pub fn load() -> Result<Self> {
+        let path = Self::registry_path();
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let contents = std::fs::read_to_string(&path)?;
+        let registry: Self = toml::from_str(&contents)?;
+        Ok(registry)
+    }
+
+    /// Persist the registry to disk.
+    pub fn save(&self) -> Result<()> {
+        let path = Self::registry_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)?;
+        std::fs::write(&path, contents)?;
+        Ok(())
+    }
+
+    /// Add an entry, ignoring duplicates (by `id`).
+    pub fn add(&mut self, entry: RegistryEntry) {
+        if !self.journals.iter().any(|e| e.id == entry.id) {
+            self.journals.push(entry);
+        }
+    }
+
+    /// Remove the entry with the given journal config ID.
+    pub fn remove_by_id(&mut self, id: Uuid) {
+        self.journals.retain(|e| e.id != id);
+    }
+}
+
+fn xdg_data_home() -> PathBuf {
+    if let Ok(val) = std::env::var("XDG_DATA_HOME") {
+        if !val.is_empty() {
+            return PathBuf::from(val);
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        return PathBuf::from(home).join(".local").join("share");
+    }
+    std::env::temp_dir()
+}
+
+/// Initialize a new journal at `storage_path`:
+/// - runs `git init`
+/// - creates `.sapphire-journal/config.toml` and `.sapphire-journal/.gitignore`
+/// - returns the stable journal ID
+pub fn init_journal(storage_path: &PathBuf) -> Result<Uuid> {
+    use sapphire_journal_core::journal::{Journal, JournalConfig};
+
+    std::fs::create_dir_all(storage_path)?;
+    git2::Repository::init(storage_path)?;
+
+    let journal_dir = storage_path.join(".sapphire-journal");
+    if journal_dir.exists() {
+        return Err(AppError::Domain(
+            "journal already initialized at this path".to_string(),
+        ));
+    }
+    std::fs::create_dir(&journal_dir)?;
+
+    let config = toml::to_string_pretty(&JournalConfig::default())?;
+    std::fs::write(journal_dir.join("config.toml"), config)?;
+    std::fs::write(journal_dir.join(".gitignore"), "cache/\n")?;
+
+    let id = Journal::from_root(storage_path.clone())
+        .map_err(|e| AppError::Domain(e.to_string()))?
+        .journal_id()
+        .map_err(|e| AppError::Domain(e.to_string()))?;
+
+    Ok(id)
+}

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -6,6 +6,7 @@ use grain_id::GrainId;
 use uuid::Uuid;
 
 use sapphire_journal_core::{
+    JournalState,
     entry::EntryHeader,
     journal::Journal,
     ops::{
@@ -30,10 +31,22 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
             }
             None => {
                 app.home = None;
+                *app.journal_state.lock().unwrap() = None;
                 show_journal_missing(app, ui);
                 return;
             }
         }
+    }
+
+    // ── Ensure JournalState is open for the current journal ───────────────
+    // Idempotent — bails out immediately when state.journal.root already
+    // matches.  Called unconditionally so the startup auto-open path (which
+    // builds HomeState in `App::new` but never enters the `if needs_init`
+    // branch here) still gets its state initialised, which is what the
+    // periodic-sync task needs to see in order to do anything.
+    let root_opt = app.home.as_ref().map(|h| h.journal_root.clone());
+    if let Some(root) = root_opt {
+        ensure_journal_state(app, &root);
     }
 
     // ── Reload entries from disk if dirty ────────────────────────────────
@@ -111,6 +124,7 @@ fn show_journal_missing(app: &mut App, ui: &mut egui::Ui) {
 // ── Sidebar ──────────────────────────────────────────────────────────────────
 
 fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
+    let mut new_entry_path: Option<PathBuf> = None;
     let home = match app.home.as_mut() {
         Some(h) => h,
         None => return,
@@ -132,6 +146,7 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                             }
                         };
                         home.needs_reload = true;
+                        new_entry_path = Some(path);
                     }
                     Err(e) => home.error_msg = Some(e.to_string()),
                 },
@@ -279,6 +294,12 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                 }
             }
         });
+
+    // Stage the freshly-created entry file with the sync backend (if any).
+    // Done after the `home` borrow ends so we can take `&mut app` here.
+    if let Some(path) = new_entry_path {
+        notify_file_updated(app, &path);
+    }
 }
 
 fn draw_tree(
@@ -400,22 +421,35 @@ fn draw_entry_row(
 // ── Editor panel ─────────────────────────────────────────────────────────────
 
 fn draw_editor_panel(app: &mut App, ui: &mut egui::Ui) {
-    let home = match app.home.as_mut() {
-        Some(h) => h,
-        None => return,
-    };
+    let do_save = {
+        let home = match app.home.as_mut() {
+            Some(h) => h,
+            None => return,
+        };
 
-    if home.editor.is_none() {
-        ui.vertical_centered(|ui| {
-            ui.add_space(40.0);
-            ui.heading("No entry selected");
-            ui.label("Pick an entry from the sidebar, or create a new one.");
-        });
-        return;
+        if home.editor.is_none() {
+            ui.vertical_centered(|ui| {
+                ui.add_space(40.0);
+                ui.heading("No entry selected");
+                ui.label("Pick an entry from the sidebar, or create a new one.");
+            });
+            return;
+        }
+
+        draw_editor_panel_inner(home, ui)
+    };
+    if do_save {
+        save_current_entry(app);
     }
+}
+
+/// Renders the editor body using an exclusive `&mut HomeState`.  Returns
+/// `true` when the Save button was clicked so the caller can apply the
+/// disk write outside the home borrow.
+fn draw_editor_panel_inner(home: &mut HomeState, ui: &mut egui::Ui) -> bool {
+    let mut do_save = false;
 
     // Header bar: id + action buttons
-    let mut do_save = false;
     let mut do_request_delete = false;
     {
         let editor = home.editor.as_ref().unwrap();
@@ -527,9 +561,7 @@ fn draw_editor_panel(app: &mut App, ui: &mut egui::Ui) {
             );
         });
 
-    if do_save {
-        save_current_entry(home);
-    }
+    do_save
 }
 
 fn draw_confirm_delete_entry(app: &mut App, ctx: &egui::Context) {
@@ -563,27 +595,35 @@ fn draw_confirm_delete_entry(app: &mut App, ctx: &egui::Context) {
         cancel = true;
     }
 
-    let home = match app.home.as_mut() {
-        Some(h) => h,
-        None => return,
-    };
+    let mut deleted_path: Option<PathBuf> = None;
+    {
+        let home = match app.home.as_mut() {
+            Some(h) => h,
+            None => return,
+        };
 
-    if cancel {
-        home.confirm_delete_entry = false;
-    }
-    if confirm {
-        home.confirm_delete_entry = false;
-        if let Some(path) = home.selected_path.clone() {
-            match remove_entry(&path) {
-                Ok(()) => {
-                    home.selected_path = None;
-                    home.editor = None;
-                    home.info_msg = None;
-                    home.needs_reload = true;
+        if cancel {
+            home.confirm_delete_entry = false;
+        }
+        if confirm {
+            home.confirm_delete_entry = false;
+            if let Some(path) = home.selected_path.clone() {
+                match remove_entry(&path) {
+                    Ok(()) => {
+                        home.selected_path = None;
+                        home.editor = None;
+                        home.info_msg = None;
+                        home.needs_reload = true;
+                        deleted_path = Some(path);
+                    }
+                    Err(e) => home.error_msg = Some(e.to_string()),
                 }
-                Err(e) => home.error_msg = Some(e.to_string()),
             }
         }
+    }
+
+    if let Some(path) = deleted_path {
+        notify_file_deleted(app, &path);
     }
 }
 
@@ -713,16 +753,23 @@ fn load_editor(path: &std::path::Path) -> Result<EditorState, String> {
     })
 }
 
-fn save_current_entry(home: &mut HomeState) {
-    let Some(path) = home.selected_path.clone() else {
-        return;
-    };
-    let Some(editor) = home.editor.as_ref() else {
-        return;
-    };
+fn save_current_entry(app: &mut App) {
+    let mut updated_path: Option<PathBuf> = None;
+    let mut renamed_from: Option<PathBuf> = None;
+    {
+        let home = match app.home.as_mut() {
+            Some(h) => h,
+            None => return,
+        };
+        let Some(path) = home.selected_path.clone() else {
+            return;
+        };
+        let Some(editor) = home.editor.as_ref() else {
+            return;
+        };
 
-    home.error_msg = None;
-    home.info_msg = None;
+        home.error_msg = None;
+        home.info_msg = None;
 
     let mut entry = match read_entry(&path) {
         Ok(e) => e,
@@ -814,21 +861,101 @@ fn save_current_entry(home: &mut HomeState) {
         return;
     }
 
-    match fix_entry(&entry.path) {
-        Ok(maybe_new) => {
-            let final_path = maybe_new.unwrap_or(entry.path.clone());
-            home.selected_path = Some(final_path.clone());
-            home.editor = match load_editor(&final_path) {
-                Ok(e) => Some(e),
-                Err(msg) => {
-                    home.error_msg = Some(msg);
-                    None
+        match fix_entry(&entry.path) {
+            Ok(maybe_new) => {
+                let final_path = maybe_new.clone().unwrap_or(entry.path.clone());
+                if let Some(new_path) = maybe_new.as_ref() {
+                    if new_path != &entry.path {
+                        renamed_from = Some(entry.path.clone());
+                    }
                 }
-            };
-            home.info_msg = Some("Saved.".to_string());
-            home.needs_reload = true;
+                home.selected_path = Some(final_path.clone());
+                home.editor = match load_editor(&final_path) {
+                    Ok(e) => Some(e),
+                    Err(msg) => {
+                        home.error_msg = Some(msg);
+                        None
+                    }
+                };
+                home.info_msg = Some("Saved.".to_string());
+                home.needs_reload = true;
+                updated_path = Some(final_path);
+            }
+            Err(e) => home.error_msg = Some(format!("fix failed: {e}")),
         }
-        Err(e) => home.error_msg = Some(format!("fix failed: {e}")),
+    }
+
+    // Notify the sync backend (outside the home borrow).  When `fix_entry`
+    // renamed the file we also untrack the previous path.
+    if let Some(old) = renamed_from {
+        notify_file_deleted(app, &old);
+    }
+    if let Some(path) = updated_path {
+        notify_file_updated(app, &path);
+    }
+}
+
+// ── Journal-state lifecycle ────────────────────────────────────────────────
+
+/// Open the journal's [`JournalState`] (cache DB + retrieve DB + sync backend)
+/// and stash it in `app.journal_state` so the periodic-sync task can use it.
+/// Idempotent: re-opening for the same `journal_root` is a no-op.
+///
+/// On a successful transition (None → Some, or different journal → this one)
+/// kicks off an initial sync so the user gets fresh remote state immediately
+/// rather than waiting up to `sync_interval_minutes` for the first tick.
+fn ensure_journal_state(app: &mut App, journal_root: &std::path::Path) {
+    let already_open = {
+        let guard = app.journal_state.lock().unwrap();
+        guard
+            .as_ref()
+            .map(|s| s.journal.root.as_path() == journal_root)
+            .unwrap_or(false)
+    };
+    if already_open {
+        return;
+    }
+    let result = Journal::from_root(journal_root.to_path_buf())
+        .map_err(|e| e.to_string())
+        .and_then(|j| JournalState::open(j).map_err(|e| e.to_string()));
+    match result {
+        Ok(state) => {
+            *app.journal_state.lock().unwrap() = Some(state);
+            trigger_manual_sync(app);
+        }
+        Err(msg) => {
+            *app.journal_state.lock().unwrap() = None;
+            if let Some(home) = app.home.as_mut() {
+                home.error_msg = Some(format!("Failed to open journal state: {msg}"));
+            }
+        }
+    }
+}
+
+/// Notify the sync backend that `path` was created or modified.
+/// Failures are reported to the home error banner.
+fn notify_file_updated(app: &mut App, path: &std::path::Path) {
+    let result = {
+        let guard = app.journal_state.lock().unwrap();
+        guard.as_ref().map(|s| s.on_file_updated(path))
+    };
+    if let Some(Err(e)) = result {
+        if let Some(home) = app.home.as_mut() {
+            home.error_msg = Some(format!("Failed to stage file: {e}"));
+        }
+    }
+}
+
+/// Notify the sync backend that `path` was deleted.
+fn notify_file_deleted(app: &mut App, path: &std::path::Path) {
+    let result = {
+        let guard = app.journal_state.lock().unwrap();
+        guard.as_ref().map(|s| s.on_file_deleted(path))
+    };
+    if let Some(Err(e)) = result {
+        if let Some(home) = app.home.as_mut() {
+            home.error_msg = Some(format!("Failed to unstage file: {e}"));
+        }
     }
 }
 
@@ -853,6 +980,7 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
 
     let mut switch_to: Option<Uuid> = None;
     let mut go_manage = false;
+    let mut sync_now = false;
 
     let response = ui.menu_button(format!("{current_name} ▾"), |ui| {
         if !others.is_empty() {
@@ -865,6 +993,10 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
             }
             ui.separator();
         }
+        if ui.button("Sync now").clicked() {
+            sync_now = true;
+            ui.close();
+        }
         if ui.button("Manage Journals…").clicked() {
             go_manage = true;
             ui.close();
@@ -874,12 +1006,50 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
 
     if let Some(id) = switch_to {
         app.home = None;
+        *app.journal_state.lock().unwrap() = None;
         app.remember_last_opened(Some(id));
         app.screen = AppState::Home { journal_id: id };
     } else if go_manage {
         app.previous_journal_id = Some(current_id);
         app.screen = AppState::List;
+    } else if sync_now {
+        trigger_manual_sync(app);
     }
+}
+
+/// Run cache + git sync once, off-thread, and report success/failure via
+/// `AppEvent`.  Lets the user verify sync independently of the 10-minute
+/// periodic tick.
+fn trigger_manual_sync(app: &mut App) {
+    let state_arc = std::sync::Arc::clone(&app.journal_state);
+    let tx = app.event_tx.clone();
+    app.runtime.spawn(async move {
+        let result = tokio::task::spawn_blocking(move || {
+            let guard = state_arc.lock().unwrap();
+            let Some(state) = guard.as_ref() else {
+                return Err("no journal is open".to_string());
+            };
+            state.sync().map_err(|e| format!("cache sync: {e}"))?;
+            state.git_sync().map_err(|e| format!("git sync: {e}"))?;
+            Ok::<(), String>(())
+        })
+        .await;
+        match result {
+            Ok(Ok(())) => {
+                let _ = tx.send(crate::app::AppEvent::EntriesNeedReload);
+            }
+            Ok(Err(msg)) => {
+                let _ = tx.send(crate::app::AppEvent::Error(format!(
+                    "Sync failed: {msg}"
+                )));
+            }
+            Err(join_err) => {
+                let _ = tx.send(crate::app::AppEvent::Error(format!(
+                    "Sync task panicked: {join_err}"
+                )));
+            }
+        }
+    });
 }
 
 // ── Display helpers ─────────────────────────────────────────────────────────

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -1,0 +1,25 @@
+use eframe::egui;
+use uuid::Uuid;
+
+use crate::app::{App, AppState};
+
+pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
+    egui::Panel::top("home_header").show_inside(ui, |ui| {
+        ui.add_space(4.0);
+        ui.horizontal(|ui| {
+            if ui.button("← Back").clicked() {
+                app.screen = AppState::List;
+            }
+        });
+        ui.add_space(4.0);
+    });
+
+    egui::CentralPanel::default().show_inside(ui, |ui| {
+        ui.vertical_centered(|ui| {
+            ui.add_space(40.0);
+            ui.heading("Journal");
+            ui.label(format!("journal_id: {journal_id}"));
+            ui.label("Entry list coming soon.");
+        });
+    });
+}

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -262,6 +262,7 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
     }
 
     let mut reparent_action: Option<(PathBuf, Option<GrainId>)> = None;
+    let mut entry_action: Option<EntryAction> = None;
     egui::ScrollArea::vertical()
         .auto_shrink([false; 2])
         .show(ui, |ui| {
@@ -271,7 +272,7 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                     for header in &filtered {
                         let path = PathBuf::from(header.path.clone());
                         let is_active = home.selected_path.as_ref() == Some(&path);
-                        if draw_entry_row(ui, header, is_active).clicked() {
+                        if draw_entry_row(ui, header, is_active, &mut entry_action).clicked() {
                             want_select = Some(path);
                         }
                     }
@@ -290,6 +291,7 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                         &mut want_select,
                         &home.entries,
                         &mut reparent_action,
+                        &mut entry_action,
                     );
                 }
             }
@@ -308,6 +310,44 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
             }
         });
 
+    match entry_action {
+        Some(EntryAction::AddChild(parent_id)) => {
+            match Journal::from_root(home.journal_root.clone()) {
+                Ok(journal) => match prepare_new_entry(&journal, Some(parent_id)) {
+                    Ok(path) => {
+                        home.selected_path = Some(path.clone());
+                        home.editor = match load_editor(&path) {
+                            Ok(e) => Some(e),
+                            Err(msg) => {
+                                home.error_msg = Some(msg);
+                                None
+                            }
+                        };
+                        home.needs_reload = true;
+                        new_entry_path = Some(path);
+                    }
+                    Err(e) => home.error_msg = Some(e.to_string()),
+                },
+                Err(e) => home.error_msg = Some(e.to_string()),
+            }
+        }
+        Some(EntryAction::RequestDelete(path)) => {
+            if home.selected_path.as_ref() != Some(&path) {
+                home.editor = match load_editor(&path) {
+                    Ok(e) => Some(e),
+                    Err(msg) => {
+                        home.error_msg = Some(msg);
+                        None
+                    }
+                };
+                home.selected_path = Some(path);
+                home.info_msg = None;
+            }
+            home.confirm_delete_entry = true;
+        }
+        None => {}
+    }
+
     // Stage the freshly-created entry file with the sync backend (if any).
     // Done after the `home` borrow ends so we can take `&mut app` here.
     if let Some(path) = new_entry_path {
@@ -316,6 +356,31 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
     if let Some((source_path, new_parent)) = reparent_action {
         apply_reparent(app, source_path, new_parent);
     }
+}
+
+#[derive(Clone)]
+enum EntryAction {
+    AddChild(GrainId),
+    RequestDelete(PathBuf),
+}
+
+fn entry_row_context_menu(
+    response: &egui::Response,
+    header: &EntryHeader,
+    pending: &mut Option<EntryAction>,
+) {
+    response.context_menu(|ui| {
+        if ui.button("Add child entry").clicked() {
+            *pending = Some(EntryAction::AddChild(header.id()));
+            ui.close();
+        }
+        if ui.button("Delete entry…").clicked() {
+            *pending = Some(EntryAction::RequestDelete(PathBuf::from(
+                header.path.clone(),
+            )));
+            ui.close();
+        }
+    });
 }
 
 fn draw_tree(
@@ -327,6 +392,7 @@ fn draw_tree(
     want_select: &mut Option<PathBuf>,
     entries: &[EntryHeader],
     reparent: &mut Option<(PathBuf, Option<GrainId>)>,
+    pending: &mut Option<EntryAction>,
 ) {
     for node in nodes {
         let id = node.entry.frontmatter.id;
@@ -372,7 +438,7 @@ fn draw_tree(
                     let layer_id = egui::LayerId::new(egui::Order::Tooltip, dnd_id);
                     let inner = ui.scope_builder(
                         egui::UiBuilder::new().layer_id(layer_id),
-                        |ui| draw_entry_row(ui, &node.entry, is_active),
+                        |ui| draw_entry_row(ui, &node.entry, is_active, pending),
                     );
                     if let Some(pos) = ui.ctx().pointer_interact_pos() {
                         let delta = pos - inner.response.rect.center();
@@ -384,13 +450,16 @@ fn draw_tree(
                     inner.response
                 } else {
                     let inner =
-                        ui.scope(|ui| draw_entry_row(ui, &node.entry, is_active));
-                    ui.interact(
-                        inner.response.rect,
-                        dnd_id,
-                        egui::Sense::click_and_drag(),
-                    )
-                    .on_hover_cursor(egui::CursorIcon::Grab)
+                        ui.scope(|ui| draw_entry_row(ui, &node.entry, is_active, pending));
+                    let outer = ui
+                        .interact(
+                            inner.response.rect,
+                            dnd_id,
+                            egui::Sense::click_and_drag(),
+                        )
+                        .on_hover_cursor(egui::CursorIcon::Grab);
+                    entry_row_context_menu(&outer, &node.entry, pending);
+                    outer
                 }
             })
             .inner;
@@ -434,6 +503,7 @@ fn draw_tree(
                 want_select,
                 entries,
                 reparent,
+                pending,
             );
         }
     }
@@ -574,6 +644,7 @@ fn draw_entry_row(
     ui: &mut egui::Ui,
     header: &EntryHeader,
     is_active: bool,
+    pending: &mut Option<EntryAction>,
 ) -> egui::Response {
     let title = if header.title().is_empty() {
         "(untitled)".to_string()
@@ -632,6 +703,7 @@ fn draw_entry_row(
     if resp.hovered() {
         ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
     }
+    entry_row_context_menu(&resp, header, pending);
     resp
 }
 

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -1,25 +1,795 @@
+use std::path::PathBuf;
+
 use eframe::egui;
 use uuid::Uuid;
 
-use crate::app::{App, AppState};
+use sapphire_journal_core::{
+    entry::EntryHeader,
+    journal::Journal,
+    labels::EntryFlag,
+    ops::{
+        EntryFilter, FieldSelector, SortField as CoreSortField, SortOrder as CoreSortOrder,
+        fix_entry, prepare_new_entry, remove_entry,
+    },
+    parser::{read_entry, write_entry},
+    period::parse_period,
+};
+
+use crate::app::{App, AppState, EditorState, HomeState};
 
 pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
-    egui::Panel::top("home_header").show_inside(ui, |ui| {
-        ui.add_space(4.0);
-        ui.horizontal(|ui| {
-            if ui.button("← Back").clicked() {
-                app.screen = AppState::List;
+    // ── Ensure HomeState matches the requested journal ────────────────────
+    let needs_init = app.home.as_ref().map(|h| h.journal_id) != Some(journal_id);
+    if needs_init {
+        match app.registry.journals.iter().find(|e| e.id == journal_id).cloned() {
+            Some(entry) => app.home = Some(HomeState::new(entry)),
+            None => {
+                app.home = None;
+                show_journal_missing(app, ui);
+                return;
             }
+        }
+    }
+
+    // ── Reload entries from disk if dirty ────────────────────────────────
+    if let Some(home) = app.home.as_mut() {
+        if home.needs_reload {
+            reload_entries(home);
+        }
+    }
+
+    // ── Layout: top header + left sidebar + central editor ───────────────
+    egui::Panel::top("home_header")
+        .resizable(false)
+        .show_inside(ui, |ui| {
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                if ui.button("← Back").clicked() {
+                    app.home = None;
+                    app.screen = AppState::List;
+                }
+                if let Some(home) = &app.home {
+                    ui.separator();
+                    ui.strong(&home.journal_name);
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        ui.small(home.journal_root.display().to_string());
+                    });
+                }
+            });
+            ui.add_space(4.0);
         });
-        ui.add_space(4.0);
+
+    if app.home.is_none() {
+        return;
+    }
+
+    egui::Panel::left("entry_sidebar")
+        .resizable(true)
+        .default_size(280.0)
+        .size_range(220.0..=480.0)
+        .show_inside(ui, |ui| {
+            draw_sidebar(app, ui);
+        });
+
+    egui::CentralPanel::default().show_inside(ui, |ui| {
+        draw_editor_panel(app, ui);
     });
 
+    // Confirm-delete-entry inline dialog
+    if app
+        .home
+        .as_ref()
+        .is_some_and(|h| h.confirm_delete_entry)
+    {
+        let ctx = ui.ctx().clone();
+        draw_confirm_delete_entry(app, &ctx);
+    }
+}
+
+// ── Helpers: missing journal ────────────────────────────────────────────────
+
+fn show_journal_missing(app: &mut App, ui: &mut egui::Ui) {
+    egui::Panel::top("home_header_missing")
+        .resizable(false)
+        .show_inside(ui, |ui| {
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                if ui.button("← Back").clicked() {
+                    app.screen = AppState::List;
+                }
+            });
+            ui.add_space(4.0);
+        });
     egui::CentralPanel::default().show_inside(ui, |ui| {
         ui.vertical_centered(|ui| {
             ui.add_space(40.0);
-            ui.heading("Journal");
-            ui.label(format!("journal_id: {journal_id}"));
-            ui.label("Entry list coming soon.");
+            ui.heading("Journal not found");
         });
     });
 }
+
+// ── Sidebar ──────────────────────────────────────────────────────────────────
+
+fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
+    let home = match app.home.as_mut() {
+        Some(h) => h,
+        None => return,
+    };
+
+    // Toolbar: New Entry + Refresh
+    ui.add_space(4.0);
+    ui.horizontal(|ui| {
+        if ui.button("+ New Entry").clicked() {
+            match Journal::from_root(home.journal_root.clone()) {
+                Ok(journal) => match prepare_new_entry(&journal, None) {
+                    Ok(path) => {
+                        home.selected_path = Some(path.clone());
+                        home.editor = match load_editor(&path) {
+                            Ok(e) => Some(e),
+                            Err(msg) => {
+                                home.error_msg = Some(msg);
+                                None
+                            }
+                        };
+                        home.needs_reload = true;
+                    }
+                    Err(e) => home.error_msg = Some(e.to_string()),
+                },
+                Err(e) => home.error_msg = Some(e.to_string()),
+            }
+        }
+        if ui.button("⟳").on_hover_text("Refresh entry list").clicked() {
+            home.needs_reload = true;
+        }
+    });
+    ui.add_space(4.0);
+
+    if let Some(msg) = home.error_msg.clone() {
+        ui.horizontal(|ui| {
+            ui.colored_label(egui::Color32::LIGHT_RED, msg);
+            if ui.small_button("×").clicked() {
+                home.error_msg = None;
+            }
+        });
+        ui.add_space(2.0);
+    }
+
+    // Search input
+    ui.label("Search");
+    ui.add(
+        egui::TextEdit::singleline(&mut home.filter_text)
+            .hint_text("Title / tag / id")
+            .desired_width(f32::INFINITY),
+    );
+
+    ui.add_space(6.0);
+
+    // Filters: period + sort
+    ui.label("Period");
+    egui::ComboBox::from_id_salt("home_period")
+        .selected_text(period_label(&home.period))
+        .width(ui.available_width())
+        .show_ui(ui, |ui| {
+            for (value, label) in PERIOD_OPTIONS {
+                ui.selectable_value(&mut home.period, (*value).to_string(), *label);
+            }
+        });
+
+    ui.add_space(4.0);
+    ui.label("Sort by");
+    egui::ComboBox::from_id_salt("home_sort_by")
+        .selected_text(sort_label(&home.sort_by))
+        .width(ui.available_width())
+        .show_ui(ui, |ui| {
+            for (value, label) in SORT_OPTIONS {
+                ui.selectable_value(&mut home.sort_by, (*value).to_string(), *label);
+            }
+        });
+
+    ui.add_space(4.0);
+    ui.label("Order");
+    egui::ComboBox::from_id_salt("home_sort_order")
+        .selected_text(if home.sort_order == "asc" {
+            "Ascending"
+        } else {
+            "Descending"
+        })
+        .width(ui.available_width())
+        .show_ui(ui, |ui| {
+            ui.selectable_value(&mut home.sort_order, "desc".to_string(), "Descending");
+            ui.selectable_value(&mut home.sort_order, "asc".to_string(), "Ascending");
+        });
+
+    ui.add_space(6.0);
+    ui.separator();
+
+    // Entry list
+    if let Some(msg) = &home.entries_error {
+        ui.colored_label(egui::Color32::LIGHT_RED, msg);
+    }
+
+    let filtered = filter_and_sort(home);
+    if filtered.is_empty() {
+        ui.add_space(8.0);
+        ui.weak("No entries match.");
+        return;
+    }
+
+    egui::ScrollArea::vertical()
+        .auto_shrink([false; 2])
+        .show(ui, |ui| {
+            let mut want_select: Option<PathBuf> = None;
+            for header in &filtered {
+                let path = PathBuf::from(header.path.clone());
+                let is_active = home.selected_path.as_ref() == Some(&path);
+                if draw_entry_row(ui, header, is_active).clicked() {
+                    want_select = Some(path);
+                }
+            }
+            if let Some(path) = want_select {
+                if home.selected_path.as_ref() != Some(&path) {
+                    home.selected_path = Some(path.clone());
+                    home.editor = match load_editor(&path) {
+                        Ok(e) => Some(e),
+                        Err(msg) => {
+                            home.error_msg = Some(msg);
+                            None
+                        }
+                    };
+                    home.info_msg = None;
+                }
+            }
+        });
+}
+
+fn draw_entry_row(
+    ui: &mut egui::Ui,
+    header: &EntryHeader,
+    is_active: bool,
+) -> egui::Response {
+    let title = if header.title().is_empty() {
+        "(untitled)".to_string()
+    } else {
+        header.title().to_string()
+    };
+    let flags: String = header
+        .flags
+        .iter()
+        .map(|f| flag_glyph(*f))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let id_str = header.id().to_string();
+    let tags_str = if header.frontmatter.tags.is_empty() {
+        String::new()
+    } else {
+        header
+            .frontmatter
+            .tags
+            .iter()
+            .map(|t| format!("#{t}"))
+            .collect::<Vec<_>>()
+            .join(" ")
+    };
+
+    let frame = if is_active {
+        egui::Frame::new()
+            .fill(ui.visuals().selection.bg_fill)
+            .inner_margin(egui::Margin::symmetric(6, 4))
+            .corner_radius(4.0)
+    } else {
+        egui::Frame::new().inner_margin(egui::Margin::symmetric(6, 4))
+    };
+
+    let resp = frame
+        .show(ui, |ui| {
+            ui.vertical(|ui| {
+                ui.horizontal(|ui| {
+                    if !flags.is_empty() {
+                        ui.label(&flags);
+                    }
+                    ui.add(egui::Label::new(egui::RichText::new(&title).strong()).truncate());
+                });
+                ui.horizontal(|ui| {
+                    ui.weak(format!("@{id_str}"));
+                    if !tags_str.is_empty() {
+                        ui.weak(tags_str);
+                    }
+                });
+            });
+        })
+        .response;
+
+    // Make the row clickable.
+    let resp = ui.interact(resp.rect, resp.id.with("row_btn"), egui::Sense::click());
+    if resp.hovered() {
+        ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+    }
+    resp
+}
+
+// ── Editor panel ─────────────────────────────────────────────────────────────
+
+fn draw_editor_panel(app: &mut App, ui: &mut egui::Ui) {
+    let home = match app.home.as_mut() {
+        Some(h) => h,
+        None => return,
+    };
+
+    if home.editor.is_none() {
+        ui.vertical_centered(|ui| {
+            ui.add_space(40.0);
+            ui.heading("No entry selected");
+            ui.label("Pick an entry from the sidebar, or create a new one.");
+        });
+        return;
+    }
+
+    // Header bar: id + action buttons
+    let mut do_save = false;
+    let mut do_request_delete = false;
+    {
+        let editor = home.editor.as_ref().unwrap();
+        ui.horizontal(|ui| {
+            ui.weak(format!("@{}", editor.id));
+            if let Some(msg) = &home.info_msg {
+                ui.colored_label(egui::Color32::LIGHT_GREEN, msg);
+            }
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui.button("Save").clicked() {
+                    do_save = true;
+                }
+                if ui.button("Delete").clicked() {
+                    do_request_delete = true;
+                }
+            });
+        });
+    }
+
+    if do_request_delete {
+        home.confirm_delete_entry = true;
+    }
+
+    ui.separator();
+
+    egui::ScrollArea::vertical()
+        .auto_shrink([false; 2])
+        .show(ui, |ui| {
+            let editor = home.editor.as_mut().unwrap();
+
+            ui.label("Title");
+            ui.add(
+                egui::TextEdit::singleline(&mut editor.title)
+                    .hint_text("Untitled")
+                    .desired_width(f32::INFINITY),
+            );
+            ui.add_space(8.0);
+
+            ui.label("Tags (comma-separated)");
+            ui.add(
+                egui::TextEdit::singleline(&mut editor.tags)
+                    .hint_text("work, journal")
+                    .desired_width(f32::INFINITY),
+            );
+            ui.add_space(8.0);
+
+            // Task fieldset
+            ui.group(|ui| {
+                ui.checkbox(&mut editor.has_task, "Task");
+                if editor.has_task {
+                    ui.horizontal(|ui| {
+                        ui.vertical(|ui| {
+                            ui.label("Status");
+                            egui::ComboBox::from_id_salt("editor_task_status")
+                                .selected_text(&editor.task_status)
+                                .show_ui(ui, |ui| {
+                                    for s in TASK_STATUS_OPTIONS {
+                                        ui.selectable_value(
+                                            &mut editor.task_status,
+                                            (*s).to_string(),
+                                            *s,
+                                        );
+                                    }
+                                });
+                        });
+                        ui.vertical(|ui| {
+                            ui.label("Due (YYYY-MM-DD)");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut editor.task_due)
+                                    .hint_text("2026-05-16")
+                                    .desired_width(160.0),
+                            );
+                        });
+                    });
+                }
+            });
+            ui.add_space(6.0);
+
+            // Event fieldset
+            ui.group(|ui| {
+                ui.checkbox(&mut editor.has_event, "Event");
+                if editor.has_event {
+                    ui.horizontal(|ui| {
+                        ui.vertical(|ui| {
+                            ui.label("Start (YYYY-MM-DD)");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut editor.event_start)
+                                    .desired_width(160.0),
+                            );
+                        });
+                        ui.vertical(|ui| {
+                            ui.label("End (YYYY-MM-DD)");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut editor.event_end)
+                                    .desired_width(160.0),
+                            );
+                        });
+                    });
+                }
+            });
+            ui.add_space(8.0);
+
+            ui.label("Body (Markdown)");
+            ui.add(
+                egui::TextEdit::multiline(&mut editor.body)
+                    .desired_rows(20)
+                    .desired_width(f32::INFINITY)
+                    .code_editor(),
+            );
+        });
+
+    if do_save {
+        save_current_entry(home);
+    }
+}
+
+fn draw_confirm_delete_entry(app: &mut App, ctx: &egui::Context) {
+    let mut cancel = false;
+    let mut confirm = false;
+    let mut open = true;
+
+    egui::Window::new("Delete entry?")
+        .collapsible(false)
+        .resizable(false)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open)
+        .show(ctx, |ui| {
+            ui.set_min_width(360.0);
+            ui.label("This will permanently delete the entry file.");
+            ui.label("This action cannot be undone.");
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Delete").clicked() {
+                        confirm = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                });
+            });
+        });
+
+    if !open {
+        cancel = true;
+    }
+
+    let home = match app.home.as_mut() {
+        Some(h) => h,
+        None => return,
+    };
+
+    if cancel {
+        home.confirm_delete_entry = false;
+    }
+    if confirm {
+        home.confirm_delete_entry = false;
+        if let Some(path) = home.selected_path.clone() {
+            match remove_entry(&path) {
+                Ok(()) => {
+                    home.selected_path = None;
+                    home.editor = None;
+                    home.info_msg = None;
+                    home.needs_reload = true;
+                }
+                Err(e) => home.error_msg = Some(e.to_string()),
+            }
+        }
+    }
+}
+
+// ── Disk operations ──────────────────────────────────────────────────────────
+
+fn reload_entries(home: &mut HomeState) {
+    home.needs_reload = false;
+    home.entries_error = None;
+    let journal = match Journal::from_root(home.journal_root.clone()) {
+        Ok(j) => j,
+        Err(e) => {
+            home.entries_error = Some(e.to_string());
+            home.entries.clear();
+            return;
+        }
+    };
+    let paths = match journal.collect_entries() {
+        Ok(p) => p,
+        Err(e) => {
+            home.entries_error = Some(e.to_string());
+            home.entries.clear();
+            return;
+        }
+    };
+    home.entries = paths
+        .iter()
+        .filter_map(|p| read_entry(p).ok().map(EntryHeader::from))
+        .collect();
+}
+
+fn filter_and_sort(home: &HomeState) -> Vec<EntryHeader> {
+    let mut headers = home.entries.clone();
+
+    // Period filter via core EntryFilter.
+    if !home.period.trim().is_empty() {
+        if let Ok(period) = parse_period(home.period.trim()) {
+            let filter = EntryFilter {
+                period: Some(period),
+                fields: FieldSelector::default(),
+                task_status: Vec::new(),
+                tags: Vec::new(),
+                sort_by: CoreSortField::Unsorted,
+                sort_order: CoreSortOrder::Asc,
+            };
+            headers.retain(|h| filter.matches(h).0);
+        }
+    }
+
+    // Substring filter on title / tags / id.
+    let needle = home.filter_text.trim().to_lowercase();
+    if !needle.is_empty() {
+        headers.retain(|h| {
+            h.title().to_lowercase().contains(&needle)
+                || h.id().to_string().to_lowercase().contains(&needle)
+                || h.frontmatter
+                    .tags
+                    .iter()
+                    .any(|t| t.to_lowercase().contains(&needle))
+        });
+    }
+
+    // Sort.
+    match home.sort_by.as_str() {
+        "title" => headers.sort_by(|a, b| a.title().cmp(b.title())),
+        "id" => headers.sort_by(|a, b| a.id().cmp(&b.id())),
+        "created_at" => headers.sort_by(|a, b| a.frontmatter.created_at.cmp(&b.frontmatter.created_at)),
+        "updated_at" => headers.sort_by(|a, b| a.frontmatter.updated_at.cmp(&b.frontmatter.updated_at)),
+        "task_due" => headers.sort_by(|a, b| {
+            let av = a.frontmatter.task.as_ref().and_then(|t| t.due);
+            let bv = b.frontmatter.task.as_ref().and_then(|t| t.due);
+            cmp_opt(av, bv)
+        }),
+        "event_start" => headers.sort_by(|a, b| {
+            let av = a.frontmatter.event.as_ref().map(|e| e.start);
+            let bv = b.frontmatter.event.as_ref().map(|e| e.start);
+            cmp_opt(av, bv)
+        }),
+        _ => {}
+    }
+    if home.sort_order == "desc" {
+        headers.reverse();
+    }
+    headers
+}
+
+fn cmp_opt<T: Ord>(a: Option<T>, b: Option<T>) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    match (a, b) {
+        (Some(x), Some(y)) => x.cmp(&y),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn load_editor(path: &std::path::Path) -> Result<EditorState, String> {
+    let entry = read_entry(path).map_err(|e| e.to_string())?;
+    let fm = &entry.frontmatter;
+    Ok(EditorState {
+        id: fm.id.to_string(),
+        title: fm.title.clone(),
+        tags: fm.tags.join(", "),
+        body: entry.body.clone(),
+        has_task: fm.task.is_some(),
+        task_status: fm
+            .task
+            .as_ref()
+            .map(|t| t.status.clone())
+            .unwrap_or_else(|| "open".to_string()),
+        task_due: fm
+            .task
+            .as_ref()
+            .and_then(|t| t.due)
+            .map(|d| d.format("%Y-%m-%d").to_string())
+            .unwrap_or_default(),
+        has_event: fm.event.is_some(),
+        event_start: fm
+            .event
+            .as_ref()
+            .map(|e| e.start.format("%Y-%m-%d").to_string())
+            .unwrap_or_default(),
+        event_end: fm
+            .event
+            .as_ref()
+            .map(|e| e.end.format("%Y-%m-%d").to_string())
+            .unwrap_or_default(),
+    })
+}
+
+fn save_current_entry(home: &mut HomeState) {
+    let Some(path) = home.selected_path.clone() else {
+        return;
+    };
+    let Some(editor) = home.editor.as_ref() else {
+        return;
+    };
+
+    home.error_msg = None;
+    home.info_msg = None;
+
+    let mut entry = match read_entry(&path) {
+        Ok(e) => e,
+        Err(e) => {
+            home.error_msg = Some(format!("read failed: {e}"));
+            return;
+        }
+    };
+
+    entry.frontmatter.title = editor.title.clone();
+    entry.frontmatter.tags = editor
+        .tags
+        .split(',')
+        .map(|t| t.trim().to_string())
+        .filter(|t| !t.is_empty())
+        .collect();
+    entry.body = editor.body.clone();
+
+    if editor.has_task {
+        let due = if editor.task_due.trim().is_empty() {
+            None
+        } else {
+            match sapphire_journal_core::period::parse_datetime_end(editor.task_due.trim()) {
+                Ok(d) => Some(d),
+                Err(e) => {
+                    home.error_msg = Some(format!("task.due: {e}"));
+                    return;
+                }
+            }
+        };
+        let status = if editor.task_status.is_empty() {
+            "open".to_string()
+        } else {
+            editor.task_status.clone()
+        };
+        let prev = entry.frontmatter.task.take();
+        entry.frontmatter.task = Some(sapphire_journal_core::entry::TaskMeta {
+            due,
+            status,
+            started_at: prev.as_ref().and_then(|t| t.started_at),
+            closed_at: prev.as_ref().and_then(|t| t.closed_at),
+            extra: prev.map(|t| t.extra).unwrap_or_default(),
+        });
+    } else {
+        entry.frontmatter.task = None;
+    }
+
+    if editor.has_event {
+        if editor.event_start.trim().is_empty() && editor.event_end.trim().is_empty() {
+            home.error_msg = Some("event requires a start or end date".to_string());
+            return;
+        }
+        let start_str = if editor.event_start.trim().is_empty() {
+            editor.event_end.trim()
+        } else {
+            editor.event_start.trim()
+        };
+        let end_str = if editor.event_end.trim().is_empty() {
+            editor.event_start.trim()
+        } else {
+            editor.event_end.trim()
+        };
+        let start = match sapphire_journal_core::period::parse_datetime(start_str) {
+            Ok(d) => d,
+            Err(e) => {
+                home.error_msg = Some(format!("event.start: {e}"));
+                return;
+            }
+        };
+        let end = match sapphire_journal_core::period::parse_datetime_end(end_str) {
+            Ok(d) => d,
+            Err(e) => {
+                home.error_msg = Some(format!("event.end: {e}"));
+                return;
+            }
+        };
+        let prev = entry.frontmatter.event.take();
+        entry.frontmatter.event = Some(sapphire_journal_core::entry::EventMeta {
+            start,
+            end,
+            extra: prev.map(|e| e.extra).unwrap_or_default(),
+        });
+    } else {
+        entry.frontmatter.event = None;
+    }
+
+    if let Err(e) = write_entry(&mut entry) {
+        home.error_msg = Some(format!("write failed: {e}"));
+        return;
+    }
+
+    match fix_entry(&entry.path) {
+        Ok(maybe_new) => {
+            let final_path = maybe_new.unwrap_or(entry.path.clone());
+            home.selected_path = Some(final_path.clone());
+            home.editor = match load_editor(&final_path) {
+                Ok(e) => Some(e),
+                Err(msg) => {
+                    home.error_msg = Some(msg);
+                    None
+                }
+            };
+            home.info_msg = Some("Saved.".to_string());
+            home.needs_reload = true;
+        }
+        Err(e) => home.error_msg = Some(format!("fix failed: {e}")),
+    }
+}
+
+// ── Display helpers ─────────────────────────────────────────────────────────
+
+fn flag_glyph(flag: EntryFlag) -> &'static str {
+    flag.to_emoji()
+}
+
+const PERIOD_OPTIONS: &[(&str, &str)] = &[
+    ("", "All"),
+    ("today", "Today"),
+    ("yesterday", "Yesterday"),
+    ("tomorrow", "Tomorrow"),
+    ("this_week", "This week"),
+    ("last_week", "Last week"),
+    ("next_week", "Next week"),
+    ("this_month", "This month"),
+    ("last_month", "Last month"),
+    ("next_month", "Next month"),
+];
+
+fn period_label(value: &str) -> &'static str {
+    PERIOD_OPTIONS
+        .iter()
+        .find(|(v, _)| *v == value)
+        .map(|(_, l)| *l)
+        .unwrap_or("All")
+}
+
+const SORT_OPTIONS: &[(&str, &str)] = &[
+    ("updated_at", "Updated"),
+    ("created_at", "Created"),
+    ("title", "Title"),
+    ("id", "ID"),
+    ("task_due", "Task due"),
+    ("event_start", "Event start"),
+];
+
+fn sort_label(value: &str) -> &'static str {
+    SORT_OPTIONS
+        .iter()
+        .find(|(v, _)| *v == value)
+        .map(|(_, l)| *l)
+        .unwrap_or("Updated")
+}
+
+const TASK_STATUS_OPTIONS: &[&str] = &[
+    "open",
+    "in_progress",
+    "done",
+    "cancelled",
+    "archived",
+];

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -1,28 +1,33 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use eframe::egui;
+use grain_id::GrainId;
 use uuid::Uuid;
 
 use sapphire_journal_core::{
     entry::EntryHeader,
     journal::Journal,
-    labels::EntryFlag,
     ops::{
-        EntryFilter, FieldSelector, SortField as CoreSortField, SortOrder as CoreSortOrder,
-        fix_entry, prepare_new_entry, remove_entry,
+        EntryFilter, EntryTreeNode, FieldSelector, SortField as CoreSortField,
+        SortOrder as CoreSortOrder, build_entry_tree, fix_entry, prepare_new_entry, remove_entry,
     },
     parser::{read_entry, write_entry},
     period::parse_period,
 };
 
-use crate::app::{App, AppState, EditorState, HomeState};
+use crate::app::{App, AppState, EditorState, HomeState, ViewMode};
+use crate::icons;
 
 pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
     // ── Ensure HomeState matches the requested journal ────────────────────
     let needs_init = app.home.as_ref().map(|h| h.journal_id) != Some(journal_id);
     if needs_init {
         match app.registry.journals.iter().find(|e| e.id == journal_id).cloned() {
-            Some(entry) => app.home = Some(HomeState::new(entry)),
+            Some(entry) => {
+                app.home = Some(HomeState::new(entry));
+                app.remember_last_opened(Some(journal_id));
+            }
             None => {
                 app.home = None;
                 show_journal_missing(app, ui);
@@ -44,13 +49,8 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
         .show_inside(ui, |ui| {
             ui.add_space(4.0);
             ui.horizontal(|ui| {
-                if ui.button("← Back").clicked() {
-                    app.home = None;
-                    app.screen = AppState::List;
-                }
+                draw_journal_switcher(app, ui, journal_id);
                 if let Some(home) = &app.home {
-                    ui.separator();
-                    ui.strong(&home.journal_name);
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.small(home.journal_root.display().to_string());
                     });
@@ -116,10 +116,10 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
         None => return,
     };
 
-    // Toolbar: New Entry + Refresh
+    // Toolbar: New Entry + Refresh + view mode toggle
     ui.add_space(4.0);
     ui.horizontal(|ui| {
-        if ui.button("+ New Entry").clicked() {
+        if icon_text_btn(ui, icons::plus(), "New Entry").clicked() {
             match Journal::from_root(home.journal_root.clone()) {
                 Ok(journal) => match prepare_new_entry(&journal, None) {
                     Ok(path) => {
@@ -138,9 +138,30 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                 Err(e) => home.error_msg = Some(e.to_string()),
             }
         }
-        if ui.button("⟳").on_hover_text("Refresh entry list").clicked() {
+        if icon_btn(ui, icons::refresh(), "Refresh entry list").clicked() {
             home.needs_reload = true;
         }
+        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+            // Show the icon for the *other* mode (i.e. what clicking would switch to).
+            let (icon, tooltip) = match home.view_mode {
+                ViewMode::Tree => (icons::list_view(), "Switch to list view"),
+                ViewMode::List => (icons::tree_view(), "Switch to tree view"),
+            };
+            if icon_btn(ui, icon, tooltip).clicked() {
+                home.view_mode = match home.view_mode {
+                    ViewMode::Tree => ViewMode::List,
+                    ViewMode::List => ViewMode::Tree,
+                };
+            }
+            let filters_tooltip = if home.show_filters {
+                "Hide filters"
+            } else {
+                "Show filters"
+            };
+            if icon_toggle_btn(ui, icons::funnel(), home.show_filters, filters_tooltip).clicked() {
+                home.show_filters = !home.show_filters;
+            }
+        });
     });
     ui.add_space(4.0);
 
@@ -162,43 +183,45 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
             .desired_width(f32::INFINITY),
     );
 
-    ui.add_space(6.0);
+    if home.show_filters {
+        ui.add_space(6.0);
 
-    // Filters: period + sort
-    ui.label("Period");
-    egui::ComboBox::from_id_salt("home_period")
-        .selected_text(period_label(&home.period))
-        .width(ui.available_width())
-        .show_ui(ui, |ui| {
-            for (value, label) in PERIOD_OPTIONS {
-                ui.selectable_value(&mut home.period, (*value).to_string(), *label);
-            }
-        });
+        // Filters: period + sort
+        ui.label("Period");
+        egui::ComboBox::from_id_salt("home_period")
+            .selected_text(period_label(&home.period))
+            .width(ui.available_width())
+            .show_ui(ui, |ui| {
+                for (value, label) in PERIOD_OPTIONS {
+                    ui.selectable_value(&mut home.period, (*value).to_string(), *label);
+                }
+            });
 
-    ui.add_space(4.0);
-    ui.label("Sort by");
-    egui::ComboBox::from_id_salt("home_sort_by")
-        .selected_text(sort_label(&home.sort_by))
-        .width(ui.available_width())
-        .show_ui(ui, |ui| {
-            for (value, label) in SORT_OPTIONS {
-                ui.selectable_value(&mut home.sort_by, (*value).to_string(), *label);
-            }
-        });
+        ui.add_space(4.0);
+        ui.label("Sort by");
+        egui::ComboBox::from_id_salt("home_sort_by")
+            .selected_text(sort_label(&home.sort_by))
+            .width(ui.available_width())
+            .show_ui(ui, |ui| {
+                for (value, label) in SORT_OPTIONS {
+                    ui.selectable_value(&mut home.sort_by, (*value).to_string(), *label);
+                }
+            });
 
-    ui.add_space(4.0);
-    ui.label("Order");
-    egui::ComboBox::from_id_salt("home_sort_order")
-        .selected_text(if home.sort_order == "asc" {
-            "Ascending"
-        } else {
-            "Descending"
-        })
-        .width(ui.available_width())
-        .show_ui(ui, |ui| {
-            ui.selectable_value(&mut home.sort_order, "desc".to_string(), "Descending");
-            ui.selectable_value(&mut home.sort_order, "asc".to_string(), "Ascending");
-        });
+        ui.add_space(4.0);
+        ui.label("Order");
+        egui::ComboBox::from_id_salt("home_sort_order")
+            .selected_text(if home.sort_order == "asc" {
+                "Ascending"
+            } else {
+                "Descending"
+            })
+            .width(ui.available_width())
+            .show_ui(ui, |ui| {
+                ui.selectable_value(&mut home.sort_order, "desc".to_string(), "Descending");
+                ui.selectable_value(&mut home.sort_order, "asc".to_string(), "Ascending");
+            });
+    }
 
     ui.add_space(6.0);
     ui.separator();
@@ -219,11 +242,27 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
         .auto_shrink([false; 2])
         .show(ui, |ui| {
             let mut want_select: Option<PathBuf> = None;
-            for header in &filtered {
-                let path = PathBuf::from(header.path.clone());
-                let is_active = home.selected_path.as_ref() == Some(&path);
-                if draw_entry_row(ui, header, is_active).clicked() {
-                    want_select = Some(path);
+            match home.view_mode {
+                ViewMode::List => {
+                    for header in &filtered {
+                        let path = PathBuf::from(header.path.clone());
+                        let is_active = home.selected_path.as_ref() == Some(&path);
+                        if draw_entry_row(ui, header, is_active).clicked() {
+                            want_select = Some(path);
+                        }
+                    }
+                }
+                ViewMode::Tree => {
+                    let pairs = filtered.into_iter().map(|h| (h, Vec::new())).collect();
+                    let tree = build_entry_tree(pairs);
+                    draw_tree(
+                        ui,
+                        &tree,
+                        0,
+                        &mut home.collapsed,
+                        &home.selected_path,
+                        &mut want_select,
+                    );
                 }
             }
             if let Some(path) = want_select {
@@ -242,6 +281,57 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
         });
 }
 
+fn draw_tree(
+    ui: &mut egui::Ui,
+    nodes: &[EntryTreeNode],
+    depth: usize,
+    collapsed: &mut HashSet<GrainId>,
+    selected: &Option<PathBuf>,
+    want_select: &mut Option<PathBuf>,
+) {
+    for node in nodes {
+        let id = node.entry.frontmatter.id;
+        let has_children = !node.children.is_empty();
+        let is_collapsed = collapsed.contains(&id);
+        let path = PathBuf::from(node.entry.path.clone());
+        let is_active = selected.as_ref() == Some(&path);
+
+        let row = ui
+            .horizontal(|ui| {
+                // Indent + collapse toggle (or spacer for leaves). The toggle
+                // and spacer use identical exact widths so parent rows and leaf
+                // rows align at the same indent.
+                ui.add_space(depth as f32 * 12.0);
+                if has_children {
+                    let icon = if is_collapsed {
+                        icons::chevron_right()
+                    } else {
+                        icons::chevron_down()
+                    };
+                    if tree_toggle(ui, icon).clicked() {
+                        if is_collapsed {
+                            collapsed.remove(&id);
+                        } else {
+                            collapsed.insert(id);
+                        }
+                    }
+                } else {
+                    ui.add_space(TREE_TOGGLE_SIZE);
+                }
+                draw_entry_row(ui, &node.entry, is_active)
+            })
+            .inner;
+
+        if row.clicked() {
+            *want_select = Some(path);
+        }
+
+        if has_children && !is_collapsed {
+            draw_tree(ui, &node.children, depth + 1, collapsed, selected, want_select);
+        }
+    }
+}
+
 fn draw_entry_row(
     ui: &mut egui::Ui,
     header: &EntryHeader,
@@ -252,12 +342,6 @@ fn draw_entry_row(
     } else {
         header.title().to_string()
     };
-    let flags: String = header
-        .flags
-        .iter()
-        .map(|f| flag_glyph(*f))
-        .collect::<Vec<_>>()
-        .join(" ");
     let id_str = header.id().to_string();
     let tags_str = if header.frontmatter.tags.is_empty() {
         String::new()
@@ -284,8 +368,14 @@ fn draw_entry_row(
         .show(ui, |ui| {
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
-                    if !flags.is_empty() {
-                        ui.label(&flags);
+                    let tint = ui.visuals().text_color();
+                    for &flag in &header.flags {
+                        ui.add(
+                            egui::Image::new(icons::flag_icon(flag))
+                                .fit_to_exact_size(egui::vec2(14.0, 14.0))
+                                .tint(tint),
+                        )
+                        .on_hover_text(flag.as_str());
                     }
                     ui.add(egui::Label::new(egui::RichText::new(&title).strong()).truncate());
                 });
@@ -338,7 +428,7 @@ fn draw_editor_panel(app: &mut App, ui: &mut egui::Ui) {
                 if ui.button("Save").clicked() {
                     do_save = true;
                 }
-                if ui.button("Delete").clicked() {
+                if icon_text_btn(ui, icons::trash(), "Delete").clicked() {
                     do_request_delete = true;
                 }
             });
@@ -742,10 +832,115 @@ fn save_current_entry(home: &mut HomeState) {
     }
 }
 
+// ── Journal switcher ────────────────────────────────────────────────────────
+
+/// Top-left "current journal" dropdown.  Shows other registered journals as
+/// clickable switch targets and a "Manage Journals…" entry that drops back to
+/// the list screen for create / clone / delete actions.
+fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
+    let current_name = app
+        .home
+        .as_ref()
+        .map(|h| h.journal_name.clone())
+        .unwrap_or_else(|| "Journal".to_string());
+    let others: Vec<(Uuid, String)> = app
+        .registry
+        .journals
+        .iter()
+        .filter(|e| e.id != current_id)
+        .map(|e| (e.id, e.name.clone()))
+        .collect();
+
+    let mut switch_to: Option<Uuid> = None;
+    let mut go_manage = false;
+
+    let response = ui.menu_button(format!("{current_name} ▾"), |ui| {
+        if !others.is_empty() {
+            ui.label("Other journals");
+            for (id, name) in &others {
+                if ui.button(name).clicked() {
+                    switch_to = Some(*id);
+                    ui.close();
+                }
+            }
+            ui.separator();
+        }
+        if ui.button("Manage Journals…").clicked() {
+            go_manage = true;
+            ui.close();
+        }
+    });
+    response.response.on_hover_text("Switch journal");
+
+    if let Some(id) = switch_to {
+        app.home = None;
+        app.remember_last_opened(Some(id));
+        app.screen = AppState::Home { journal_id: id };
+    } else if go_manage {
+        app.previous_journal_id = Some(current_id);
+        app.screen = AppState::List;
+    }
+}
+
 // ── Display helpers ─────────────────────────────────────────────────────────
 
-fn flag_glyph(flag: EntryFlag) -> &'static str {
-    flag.to_emoji()
+/// Square icon-only button (16×16) with a tooltip.
+fn icon_btn(
+    ui: &mut egui::Ui,
+    src: egui::ImageSource<'static>,
+    tooltip: &str,
+) -> egui::Response {
+    let tint = ui.visuals().text_color();
+    let img = egui::Image::new(src)
+        .fit_to_exact_size(egui::vec2(16.0, 16.0))
+        .tint(tint);
+    ui.add(egui::Button::image(img)).on_hover_text(tooltip)
+}
+
+/// Toggleable icon button — renders with a pressed/highlighted background
+/// when `active` is true.
+fn icon_toggle_btn(
+    ui: &mut egui::Ui,
+    src: egui::ImageSource<'static>,
+    active: bool,
+    tooltip: &str,
+) -> egui::Response {
+    let tint = ui.visuals().text_color();
+    let img = egui::Image::new(src)
+        .fit_to_exact_size(egui::vec2(16.0, 16.0))
+        .tint(tint);
+    ui.add(egui::Button::image(img).selected(active))
+        .on_hover_text(tooltip)
+}
+
+/// Icon + text button (14×14 icon to align with the label height).
+fn icon_text_btn(
+    ui: &mut egui::Ui,
+    src: egui::ImageSource<'static>,
+    text: &str,
+) -> egui::Response {
+    let tint = ui.visuals().text_color();
+    let img = egui::Image::new(src)
+        .fit_to_exact_size(egui::vec2(14.0, 14.0))
+        .tint(tint);
+    ui.add(egui::Button::image_and_text(img, text))
+}
+
+/// Exact width reserved for the tree expand/collapse toggle (and the
+/// matching leaf spacer).  Kept narrow so titles align with leaf rows.
+const TREE_TOGGLE_SIZE: f32 = 14.0;
+
+/// Frameless expand/collapse triangle for tree rows.  Matches `TREE_TOGGLE_SIZE`
+/// exactly so leaf rows (which insert a spacer of the same width) stay aligned.
+fn tree_toggle(ui: &mut egui::Ui, src: egui::ImageSource<'static>) -> egui::Response {
+    let tint = ui.visuals().weak_text_color();
+    let img = egui::Image::new(src)
+        .fit_to_exact_size(egui::vec2(TREE_TOGGLE_SIZE, TREE_TOGGLE_SIZE))
+        .tint(tint);
+    ui.add_sized(
+        [TREE_TOGGLE_SIZE, TREE_TOGGLE_SIZE],
+        egui::Button::image(img).frame(false),
+    )
 }
 
 const PERIOD_OPTIONS: &[(&str, &str)] = &[

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -362,14 +362,36 @@ fn draw_tree(
                     );
                 }
                 let dnd_id = egui::Id::new(("entry_dnd", id));
-                // dnd_drag_source returns an InnerResponse where `.inner` carries
-                // the row's click-sense response and `.response` carries the
-                // drag-sense + drop-detection response. Union both so the row
-                // remains clickable for selection AND acts as a drop target.
-                let dnd = ui.dnd_drag_source(dnd_id, id, |ui| {
-                    draw_entry_row(ui, &node.entry, is_active)
-                });
-                dnd.inner | dnd.response
+                // Inlined `dnd_drag_source` using `Sense::click_and_drag()` so
+                // a press-and-release without movement registers as a click
+                // (for selection) while a press-and-drag still starts a drag.
+                // The stock `dnd_drag_source` overlays a `Sense::drag()` widget
+                // that shadows the row's click sense, so clicks were lost.
+                if ui.ctx().is_being_dragged(dnd_id) {
+                    egui::DragAndDrop::set_payload(ui.ctx(), id);
+                    let layer_id = egui::LayerId::new(egui::Order::Tooltip, dnd_id);
+                    let inner = ui.scope_builder(
+                        egui::UiBuilder::new().layer_id(layer_id),
+                        |ui| draw_entry_row(ui, &node.entry, is_active),
+                    );
+                    if let Some(pos) = ui.ctx().pointer_interact_pos() {
+                        let delta = pos - inner.response.rect.center();
+                        ui.ctx().transform_layer_shapes(
+                            layer_id,
+                            egui::emath::TSTransform::from_translation(delta),
+                        );
+                    }
+                    inner.response
+                } else {
+                    let inner =
+                        ui.scope(|ui| draw_entry_row(ui, &node.entry, is_active));
+                    ui.interact(
+                        inner.response.rect,
+                        dnd_id,
+                        egui::Sense::click_and_drag(),
+                    )
+                    .on_hover_cursor(egui::CursorIcon::Grab)
+                }
             })
             .inner;
 

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -99,6 +99,12 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
         let ctx = ui.ctx().clone();
         draw_confirm_delete_entry(app, &ctx);
     }
+
+    // Settings panel (opened from the journal-switcher menu)
+    if app.settings_panel.is_some() {
+        let ctx = ui.ctx().clone();
+        crate::screens::settings_panel::show(app, &ctx);
+    }
 }
 
 // ── Helpers: missing journal ────────────────────────────────────────────────
@@ -1170,6 +1176,7 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
     let mut switch_to: Option<Uuid> = None;
     let mut go_manage = false;
     let mut sync_now = false;
+    let mut open_settings = false;
 
     let response = ui.menu_button(format!("{current_name} ▾"), |ui| {
         if !others.is_empty() {
@@ -1184,6 +1191,10 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
         }
         if ui.button("Sync now").clicked() {
             sync_now = true;
+            ui.close();
+        }
+        if ui.button("Settings…").clicked() {
+            open_settings = true;
             ui.close();
         }
         if ui.button("Manage Journals…").clicked() {
@@ -1203,6 +1214,13 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
         app.screen = AppState::List;
     } else if sync_now {
         trigger_manual_sync(app);
+    } else if open_settings {
+        if let Some(home) = app.home.as_ref() {
+            let root = home.journal_root.clone();
+            app.settings_panel = Some(
+                crate::screens::settings_panel::SettingsPanelState::open(root),
+            );
+        }
     }
 }
 

--- a/sapphire-journal-gui/src/screens/journal_home.rs
+++ b/sapphire-journal-gui/src/screens/journal_home.rs
@@ -8,10 +8,12 @@ use uuid::Uuid;
 use sapphire_journal_core::{
     JournalState,
     entry::EntryHeader,
+    entry_ref::EntryRef,
     journal::Journal,
     ops::{
-        EntryFilter, EntryTreeNode, FieldSelector, SortField as CoreSortField,
-        SortOrder as CoreSortOrder, build_entry_tree, fix_entry, prepare_new_entry, remove_entry,
+        EntryFields, EntryFilter, EntryTreeNode, FieldSelector, SortField as CoreSortField,
+        SortOrder as CoreSortOrder, UpdateOption, build_entry_tree, fix_entry, prepare_new_entry,
+        remove_entry, update_entry,
     },
     parser::{read_entry, write_entry},
     period::parse_period,
@@ -253,6 +255,7 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
         return;
     }
 
+    let mut reparent_action: Option<(PathBuf, Option<GrainId>)> = None;
     egui::ScrollArea::vertical()
         .auto_shrink([false; 2])
         .show(ui, |ui| {
@@ -268,6 +271,8 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                     }
                 }
                 ViewMode::Tree => {
+                    // Root drop zone: dropping above the first row clears `parent_id`.
+                    draw_root_drop_zone(ui, &home.entries, &mut reparent_action);
                     let pairs = filtered.into_iter().map(|h| (h, Vec::new())).collect();
                     let tree = build_entry_tree(pairs);
                     draw_tree(
@@ -277,6 +282,8 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
                         &mut home.collapsed,
                         &home.selected_path,
                         &mut want_select,
+                        &home.entries,
+                        &mut reparent_action,
                     );
                 }
             }
@@ -300,6 +307,9 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
     if let Some(path) = new_entry_path {
         notify_file_updated(app, &path);
     }
+    if let Some((source_path, new_parent)) = reparent_action {
+        apply_reparent(app, source_path, new_parent);
+    }
 }
 
 fn draw_tree(
@@ -309,6 +319,8 @@ fn draw_tree(
     collapsed: &mut HashSet<GrainId>,
     selected: &Option<PathBuf>,
     want_select: &mut Option<PathBuf>,
+    entries: &[EntryHeader],
+    reparent: &mut Option<(PathBuf, Option<GrainId>)>,
 ) {
     for node in nodes {
         let id = node.entry.frontmatter.id;
@@ -319,9 +331,10 @@ fn draw_tree(
 
         let row = ui
             .horizontal(|ui| {
-                // Indent + collapse toggle (or spacer for leaves). The toggle
-                // and spacer use identical exact widths so parent rows and leaf
-                // rows align at the same indent.
+                // Indent + collapse toggle (or spacer for leaves). The spacer
+                // is allocated as a widget (not raw `add_space`) so the same
+                // `item_spacing.x` is inserted on each side as for the chevron
+                // button — keeping leaf rows aligned with parent rows.
                 ui.add_space(depth as f32 * 12.0);
                 if has_children {
                     let icon = if is_collapsed {
@@ -337,20 +350,196 @@ fn draw_tree(
                         }
                     }
                 } else {
-                    ui.add_space(TREE_TOGGLE_SIZE);
+                    ui.allocate_exact_size(
+                        egui::vec2(TREE_TOGGLE_SIZE, TREE_TOGGLE_SIZE),
+                        egui::Sense::hover(),
+                    );
                 }
-                draw_entry_row(ui, &node.entry, is_active)
+                let dnd_id = egui::Id::new(("entry_dnd", id));
+                // dnd_drag_source returns an InnerResponse where `.inner` carries
+                // the row's click-sense response and `.response` carries the
+                // drag-sense + drop-detection response. Union both so the row
+                // remains clickable for selection AND acts as a drop target.
+                let dnd = ui.dnd_drag_source(dnd_id, id, |ui| {
+                    draw_entry_row(ui, &node.entry, is_active)
+                });
+                dnd.inner | dnd.response
             })
             .inner;
 
         if row.clicked() {
-            *want_select = Some(path);
+            *want_select = Some(path.clone());
+        }
+
+        // ── drag-and-drop drop target ────────────────────────────────────
+        // Highlight the row when something is being dragged over it.
+        if let Some(payload) = row.dnd_hover_payload::<GrainId>() {
+            let src = *payload;
+            let would_be_cycle = is_descendant_or_self(entries, src, id);
+            let stroke = if would_be_cycle {
+                egui::Stroke::new(1.5, egui::Color32::DARK_RED)
+            } else {
+                egui::Stroke::new(1.5, ui.visuals().selection.bg_fill)
+            };
+            ui.painter()
+                .rect_stroke(row.rect, 4.0, stroke, egui::StrokeKind::Inside);
+        }
+        if let Some(payload) = row.dnd_release_payload::<GrainId>() {
+            let src = *payload;
+            if src != id && !is_descendant_or_self(entries, src, id) {
+                if let Some(header) = entries.iter().find(|e| e.frontmatter.id == src) {
+                    // Only act when the parent actually changes.
+                    if header.frontmatter.parent_id != Some(id) {
+                        *reparent = Some((PathBuf::from(header.path.clone()), Some(id)));
+                    }
+                }
+            }
         }
 
         if has_children && !is_collapsed {
-            draw_tree(ui, &node.children, depth + 1, collapsed, selected, want_select);
+            draw_tree(
+                ui,
+                &node.children,
+                depth + 1,
+                collapsed,
+                selected,
+                want_select,
+                entries,
+                reparent,
+            );
         }
     }
+}
+
+/// Returns `true` if `candidate` is `ancestor` itself, or any descendant of
+/// `ancestor`, by walking the `parent_id` chain on `candidate`.  Used to
+/// prevent the user from dropping an entry into its own subtree.
+fn is_descendant_or_self(
+    entries: &[EntryHeader],
+    ancestor: GrainId,
+    candidate: GrainId,
+) -> bool {
+    if candidate == ancestor {
+        return true;
+    }
+    let mut current = candidate;
+    let mut seen: HashSet<GrainId> = HashSet::new();
+    loop {
+        if !seen.insert(current) {
+            return false;
+        }
+        let entry = match entries.iter().find(|e| e.frontmatter.id == current) {
+            Some(e) => e,
+            None => return false,
+        };
+        match entry.frontmatter.parent_id {
+            Some(pid) if pid == ancestor => return true,
+            Some(pid) => current = pid,
+            None => return false,
+        }
+    }
+}
+
+/// Thin strip at the top of the tree that accepts drops to clear `parent_id`
+/// (make the entry top-level).  Only renders visibly when a drag is in
+/// progress, so it doesn't add chrome the rest of the time.
+fn draw_root_drop_zone(
+    ui: &mut egui::Ui,
+    entries: &[EntryHeader],
+    reparent: &mut Option<(PathBuf, Option<GrainId>)>,
+) {
+    let is_dragging = egui::DragAndDrop::has_payload_of_type::<GrainId>(ui.ctx());
+    if !is_dragging {
+        return;
+    }
+    let (rect, resp) = ui.allocate_exact_size(
+        egui::vec2(ui.available_width(), 20.0),
+        egui::Sense::hover(),
+    );
+    let visuals = ui.visuals();
+    let is_hover = resp.contains_pointer();
+    let bg = if is_hover {
+        visuals.selection.bg_fill
+    } else {
+        visuals.widgets.inactive.bg_fill
+    };
+    ui.painter().rect_filled(rect, 4.0, bg);
+    ui.painter().text(
+        rect.center(),
+        egui::Align2::CENTER_CENTER,
+        "Drop here for top level",
+        egui::FontId::proportional(11.0),
+        visuals.text_color(),
+    );
+    if let Some(payload) = resp.dnd_release_payload::<GrainId>() {
+        let src = *payload;
+        if let Some(header) = entries.iter().find(|e| e.frontmatter.id == src) {
+            if header.frontmatter.parent_id.is_some() {
+                *reparent = Some((PathBuf::from(header.path.clone()), None));
+            }
+        }
+    }
+}
+
+/// Apply a drag-and-drop reparenting action: rewrite the source entry's
+/// `parent_id` via [`update_entry`], update any path rename, and notify the
+/// sync backend.  Runs outside the `home` borrow so it can take `&mut App`.
+fn apply_reparent(app: &mut App, source_path: PathBuf, new_parent: Option<GrainId>) {
+    let conn_result = {
+        let guard = app.journal_state.lock().unwrap();
+        guard.as_ref().map(|s| s.open_conn())
+    };
+    let conn = match conn_result {
+        Some(Ok(c)) => c,
+        Some(Err(e)) => {
+            if let Some(home) = app.home.as_mut() {
+                home.error_msg = Some(format!("Failed to open cache: {e}"));
+            }
+            return;
+        }
+        None => {
+            if let Some(home) = app.home.as_mut() {
+                home.error_msg = Some("No journal is open".to_string());
+            }
+            return;
+        }
+    };
+
+    let parent_field = match new_parent {
+        Some(id) => UpdateOption::Set(EntryRef::Id(id)),
+        None => UpdateOption::Clear,
+    };
+    let fields = EntryFields {
+        parent: parent_field,
+        ..Default::default()
+    };
+
+    let renamed = match update_entry(&source_path, &conn, fields) {
+        Ok(maybe_new) => maybe_new,
+        Err(e) => {
+            if let Some(home) = app.home.as_mut() {
+                home.error_msg = Some(format!("Reparent failed: {e}"));
+            }
+            return;
+        }
+    };
+    drop(conn);
+
+    let final_path = renamed.clone().unwrap_or_else(|| source_path.clone());
+    // Track selection if it moved with the rename.
+    if let Some(home) = app.home.as_mut() {
+        if home.selected_path.as_deref() == Some(source_path.as_path()) {
+            home.selected_path = Some(final_path.clone());
+        }
+        home.needs_reload = true;
+        home.info_msg = Some("Reparented.".to_string());
+    }
+    if let Some(new_path) = renamed.as_ref() {
+        if new_path != &source_path {
+            notify_file_deleted(app, &source_path);
+        }
+    }
+    notify_file_updated(app, &final_path);
 }
 
 fn draw_entry_row(

--- a/sapphire-journal-gui/src/screens/journal_list.rs
+++ b/sapphire-journal-gui/src/screens/journal_list.rs
@@ -1,0 +1,115 @@
+use std::sync::{Arc, Mutex};
+
+use eframe::egui;
+
+use crate::app::{
+    App, AppState, CloneState, ConfirmDeleteState, DialogKind, DialogState, NewJournalState,
+};
+use crate::dialogs;
+
+pub fn show(app: &mut App, ui: &mut egui::Ui) {
+    egui::Panel::top("list_header").show_inside(ui, |ui| {
+        ui.add_space(4.0);
+        ui.horizontal(|ui| {
+            ui.heading("Sapphire Journal");
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui.button("Clone").clicked() && app.dialog.is_none() {
+                    app.dialog = Some(DialogState::Clone(CloneState {
+                        name: String::new(),
+                        url: String::new(),
+                        progress: Arc::new(Mutex::new(None)),
+                    }));
+                }
+                if ui.button("New Journal").clicked() && app.dialog.is_none() {
+                    app.dialog = Some(DialogState::NewJournal(NewJournalState {
+                        name: String::new(),
+                        in_progress: false,
+                    }));
+                }
+            });
+        });
+        ui.add_space(4.0);
+    });
+
+    if let Some(msg) = app.error_msg.clone() {
+        egui::Panel::top("error_banner").show_inside(ui, |ui| {
+            ui.add_space(2.0);
+            ui.horizontal(|ui| {
+                ui.colored_label(egui::Color32::LIGHT_RED, msg);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.small_button("×").clicked() {
+                        app.error_msg = None;
+                    }
+                });
+            });
+            ui.add_space(2.0);
+        });
+    }
+
+    egui::CentralPanel::default().show_inside(ui, |ui| {
+        let journals = app.registry.journals.clone();
+
+        if journals.is_empty() {
+            ui.vertical_centered(|ui| {
+                ui.add_space(40.0);
+                ui.label("No journals yet.");
+                ui.label("Create a new journal or clone an existing one to get started.");
+            });
+        } else {
+            egui::ScrollArea::vertical().show(ui, |ui| {
+                for entry in journals {
+                    let reachable = entry.storage_path.join(".sapphire-journal").is_dir();
+                    egui::Frame::group(ui.style()).show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.vertical(|ui| {
+                                ui.horizontal(|ui| {
+                                    ui.strong(&entry.name);
+                                    if !reachable {
+                                        ui.colored_label(
+                                            egui::Color32::YELLOW,
+                                            "unreachable",
+                                        );
+                                    }
+                                });
+                                ui.small(entry.storage_path.display().to_string());
+                            });
+                            ui.with_layout(
+                                egui::Layout::right_to_left(egui::Align::Center),
+                                |ui| {
+                                    if ui.button("Delete").clicked() && app.dialog.is_none() {
+                                        app.dialog = Some(DialogState::ConfirmDelete(
+                                            ConfirmDeleteState {
+                                                entry: entry.clone(),
+                                                typed: String::new(),
+                                                in_progress: false,
+                                            },
+                                        ));
+                                    }
+                                    let open = ui
+                                        .add_enabled(reachable, egui::Button::new("Open"))
+                                        .clicked();
+                                    if open {
+                                        app.screen = AppState::Home {
+                                            journal_id: entry.id,
+                                        };
+                                    }
+                                },
+                            );
+                        });
+                    });
+                    ui.add_space(4.0);
+                }
+            });
+        }
+    });
+
+    // Render the active dialog (if any) on top of the screen.
+    let dialog_kind = app.dialog.as_ref().map(DialogState::kind);
+    let ctx = ui.ctx().clone();
+    match dialog_kind {
+        Some(DialogKind::NewJournal) => dialogs::new_journal::show(app, &ctx),
+        Some(DialogKind::Clone) => dialogs::clone::show(app, &ctx),
+        Some(DialogKind::ConfirmDelete) => dialogs::confirm_delete::show(app, &ctx),
+        None => {}
+    }
+}

--- a/sapphire-journal-gui/src/screens/journal_list.rs
+++ b/sapphire-journal-gui/src/screens/journal_list.rs
@@ -14,6 +14,14 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
     egui::Panel::top("list_header").show_inside(ui, |ui| {
         ui.add_space(4.0);
         ui.horizontal(|ui| {
+            if let Some(prev_id) = app.previous_journal_id {
+                if ui.button("← Back").clicked() {
+                    app.screen = AppState::Home { journal_id: prev_id };
+                    app.previous_journal_id = None;
+                    return;
+                }
+                ui.separator();
+            }
             ui.heading("Sapphire Journal");
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 if ui.button("Clone").clicked() && app.dialog.is_none() {
@@ -102,6 +110,8 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                                         .add_enabled(reachable, egui::Button::new("Open"))
                                         .clicked();
                                     if open {
+                                        app.previous_journal_id = None;
+                                        app.remember_last_opened(Some(entry.id));
                                         app.screen = AppState::Home {
                                             journal_id: entry.id,
                                         };

--- a/sapphire-journal-gui/src/screens/journal_list.rs
+++ b/sapphire-journal-gui/src/screens/journal_list.rs
@@ -1,11 +1,14 @@
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use eframe::egui;
+use sapphire_journal_core::journal::Journal;
 
 use crate::app::{
     App, AppState, CloneState, ConfirmDeleteState, DialogKind, DialogState, NewJournalState,
 };
 use crate::dialogs;
+use crate::registry::{JournalRegistry, RegistryEntry};
 
 pub fn show(app: &mut App, ui: &mut egui::Ui) {
     egui::Panel::top("list_header").show_inside(ui, |ui| {
@@ -19,6 +22,16 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
                         url: String::new(),
                         progress: Arc::new(Mutex::new(None)),
                     }));
+                }
+                if ui.button("Open Existing…").clicked() && app.dialog.is_none() {
+                    if let Some(path) = rfd::FileDialog::new()
+                        .set_title("Open Sapphire Journal")
+                        .pick_folder()
+                    {
+                        if let Err(msg) = register_existing(&mut app.registry, path) {
+                            app.error_msg = Some(msg);
+                        }
+                    }
                 }
                 if ui.button("New Journal").clicked() && app.dialog.is_none() {
                     app.dialog = Some(DialogState::NewJournal(NewJournalState {
@@ -53,7 +66,7 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
             ui.vertical_centered(|ui| {
                 ui.add_space(40.0);
                 ui.label("No journals yet.");
-                ui.label("Create a new journal or clone an existing one to get started.");
+                ui.label("Create a new journal, open an existing one, or clone one to get started.");
             });
         } else {
             egui::ScrollArea::vertical().show(ui, |ui| {
@@ -112,4 +125,30 @@ pub fn show(app: &mut App, ui: &mut egui::Ui) {
         Some(DialogKind::ConfirmDelete) => dialogs::confirm_delete::show(app, &ctx),
         None => {}
     }
+}
+
+fn register_existing(registry: &mut JournalRegistry, path: PathBuf) -> Result<(), String> {
+    let journal = Journal::from_root(path.clone()).map_err(|_| {
+        format!(
+            "Not a sapphire journal (missing .sapphire-journal/): {}",
+            path.display()
+        )
+    })?;
+    let id = journal.journal_id().map_err(|e| e.to_string())?;
+
+    if let Some(existing) = registry.journals.iter().find(|e| e.id == id) {
+        return Err(format!("Already registered as \"{}\".", existing.name));
+    }
+
+    let name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("Untitled")
+        .to_string();
+    registry.add(RegistryEntry {
+        id,
+        name,
+        storage_path: path,
+    });
+    registry.save().map_err(|e| e.to_string())
 }

--- a/sapphire-journal-gui/src/screens/mod.rs
+++ b/sapphire-journal-gui/src/screens/mod.rs
@@ -1,0 +1,2 @@
+pub mod journal_home;
+pub mod journal_list;

--- a/sapphire-journal-gui/src/screens/mod.rs
+++ b/sapphire-journal-gui/src/screens/mod.rs
@@ -1,2 +1,3 @@
 pub mod journal_home;
 pub mod journal_list;
+pub mod settings_panel;

--- a/sapphire-journal-gui/src/screens/settings_panel.rs
+++ b/sapphire-journal-gui/src/screens/settings_panel.rs
@@ -1,0 +1,283 @@
+//! Settings panel — per-journal (`.sapphire-journal/config.toml` + git remote)
+//! and global (`$XDG_CONFIG_HOME/sapphire-journal/config.toml`) preferences.
+//!
+//! Opened from the journal-switcher menu in `journal_home`.
+
+use std::path::{Path, PathBuf};
+
+use eframe::egui;
+
+use sapphire_journal_core::{
+    journal::{DuplicateTitlePolicy, Journal, JournalConfig},
+    user_config::{SyncBackendKind, UserConfig},
+};
+
+use crate::app::App;
+
+const DUP_TITLE_OPTIONS: &[&str] = &["allow", "warn", "error"];
+const SYNC_BACKEND_OPTIONS: &[&str] = &["auto", "none", "git"];
+
+pub struct SettingsPanelState {
+    journal_root: PathBuf,
+
+    // ── Per-journal ────────────────────────────────────────────────────────
+    git_remote: String,
+    duplicate_title: String,
+    entries_dir: String,
+
+    // ── Global ─────────────────────────────────────────────────────────────
+    sync_interval_minutes: String,
+    sync_backend: String,
+
+    error_msg: Option<String>,
+    info_msg: Option<String>,
+}
+
+impl SettingsPanelState {
+    /// Build the state by reading current on-disk values.
+    pub fn open(journal_root: PathBuf) -> Self {
+        let journal_cfg = Journal::from_root(journal_root.clone())
+            .and_then(|j| j.config())
+            .unwrap_or_default();
+        let duplicate_title = match journal_cfg.journal.duplicate_title {
+            DuplicateTitlePolicy::Allow => "allow",
+            DuplicateTitlePolicy::Warn => "warn",
+            DuplicateTitlePolicy::Error => "error",
+        }
+        .to_string();
+        let entries_dir = journal_cfg.journal.entries_dir.unwrap_or_default();
+        let git_remote = git2::Repository::open(&journal_root)
+            .ok()
+            .and_then(|repo| {
+                repo.find_remote("origin")
+                    .ok()
+                    .and_then(|r| r.url().map(str::to_owned))
+            })
+            .unwrap_or_default();
+
+        let user_cfg = UserConfig::load().unwrap_or_default();
+        let sync_interval_minutes = user_cfg
+            .sync_interval_minutes
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "10".to_string());
+        let sync_backend = match user_cfg.sync.backend {
+            SyncBackendKind::Auto => "auto",
+            SyncBackendKind::None => "none",
+            SyncBackendKind::Git => "git",
+        }
+        .to_string();
+
+        Self {
+            journal_root,
+            git_remote,
+            duplicate_title,
+            entries_dir,
+            sync_interval_minutes,
+            sync_backend,
+            error_msg: None,
+            info_msg: None,
+        }
+    }
+
+    fn save(&mut self) -> bool {
+        self.error_msg = None;
+        self.info_msg = None;
+
+        let interval = match self.sync_interval_minutes.trim().parse::<u32>() {
+            Ok(n) => n,
+            Err(_) => {
+                self.error_msg =
+                    Some("Sync interval must be a non-negative integer (0 to disable).".to_string());
+                return false;
+            }
+        };
+
+        let mut user_cfg = UserConfig::load().unwrap_or_default();
+        user_cfg.sync_interval_minutes = Some(interval);
+        user_cfg.sync.backend = match self.sync_backend.as_str() {
+            "none" => SyncBackendKind::None,
+            "git" => SyncBackendKind::Git,
+            _ => SyncBackendKind::Auto,
+        };
+        if let Err(e) = write_user_config(&user_cfg) {
+            self.error_msg = Some(format!("Failed to save user config: {e}"));
+            return false;
+        }
+
+        let journal = match Journal::from_root(self.journal_root.clone()) {
+            Ok(j) => j,
+            Err(e) => {
+                self.error_msg = Some(format!("Failed to open journal: {e}"));
+                return false;
+            }
+        };
+        let mut jc = journal.config().unwrap_or_default();
+        jc.journal.duplicate_title = match self.duplicate_title.as_str() {
+            "allow" => DuplicateTitlePolicy::Allow,
+            "error" => DuplicateTitlePolicy::Error,
+            _ => DuplicateTitlePolicy::Warn,
+        };
+        let new_entries_dir = if self.entries_dir.trim().is_empty() {
+            None
+        } else {
+            Some(self.entries_dir.trim().to_string())
+        };
+        let entries_dir_changed = jc.journal.entries_dir != new_entries_dir;
+        jc.journal.entries_dir = new_entries_dir;
+        if let Err(e) = write_journal_config(&journal, &jc) {
+            self.error_msg = Some(format!("Failed to save journal config: {e}"));
+            return false;
+        }
+
+        if !self.git_remote.trim().is_empty() {
+            if let Err(e) = set_git_remote(&self.journal_root, self.git_remote.trim()) {
+                self.error_msg = Some(format!("Failed to set git remote: {e}"));
+                return false;
+            }
+        }
+
+        self.info_msg = Some(if entries_dir_changed {
+            "Saved. Restart or refresh to see entries from the new directory."
+        } else {
+            "Saved."
+        }
+        .to_string());
+        true
+    }
+}
+
+fn write_user_config(cfg: &UserConfig) -> Result<(), String> {
+    let path = UserConfig::path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let content = toml::to_string_pretty(cfg).map_err(|e| e.to_string())?;
+    std::fs::write(&path, content).map_err(|e| e.to_string())
+}
+
+fn write_journal_config(journal: &Journal, cfg: &JournalConfig) -> Result<(), String> {
+    let path = journal.journal_dir().join("config.toml");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let content = toml::to_string_pretty(cfg).map_err(|e| e.to_string())?;
+    std::fs::write(&path, content).map_err(|e| e.to_string())
+}
+
+fn set_git_remote(journal_root: &Path, url: &str) -> Result<(), String> {
+    let repo = git2::Repository::open(journal_root).map_err(|e| e.to_string())?;
+    match repo.find_remote("origin") {
+        Ok(_) => {
+            repo.remote_set_url("origin", url).map_err(|e| e.to_string())?;
+        }
+        Err(_) => {
+            repo.remote("origin", url).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+/// Render the panel.  No-op when `app.settings_panel` is `None`.
+pub fn show(app: &mut App, ctx: &egui::Context) {
+    let mut close = false;
+    let mut do_save = false;
+    let mut open_flag = true;
+
+    let Some(state) = app.settings_panel.as_mut() else {
+        return;
+    };
+
+    egui::Window::new("Settings")
+        .collapsible(false)
+        .resizable(true)
+        .default_width(480.0)
+        .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+        .open(&mut open_flag)
+        .show(ctx, |ui| {
+            ui.heading("This journal");
+            ui.add_space(4.0);
+
+            ui.label("Git remote (origin)");
+            ui.add(
+                egui::TextEdit::singleline(&mut state.git_remote)
+                    .hint_text("git@github.com:user/repo.git")
+                    .desired_width(f32::INFINITY),
+            );
+            ui.weak("Empty input leaves the remote unchanged.  Use `git` to remove it.");
+            ui.add_space(6.0);
+
+            ui.label("Duplicate title policy");
+            egui::ComboBox::from_id_salt("settings_dup_title")
+                .selected_text(&state.duplicate_title)
+                .width(ui.available_width())
+                .show_ui(ui, |ui| {
+                    for v in DUP_TITLE_OPTIONS {
+                        ui.selectable_value(&mut state.duplicate_title, (*v).to_string(), *v);
+                    }
+                });
+            ui.add_space(6.0);
+
+            ui.label("Entries directory (relative to journal root; blank = root)");
+            ui.add(
+                egui::TextEdit::singleline(&mut state.entries_dir)
+                    .hint_text("entries")
+                    .desired_width(f32::INFINITY),
+            );
+
+            ui.add_space(10.0);
+            ui.separator();
+            ui.add_space(6.0);
+
+            ui.heading("Global");
+            ui.weak("Applies to all journals — takes effect on next launch.");
+            ui.add_space(4.0);
+
+            ui.label("Sync interval (minutes; 0 to disable)");
+            ui.add(
+                egui::TextEdit::singleline(&mut state.sync_interval_minutes)
+                    .desired_width(80.0),
+            );
+            ui.add_space(6.0);
+
+            ui.label("Sync backend");
+            egui::ComboBox::from_id_salt("settings_sync_backend")
+                .selected_text(&state.sync_backend)
+                .width(ui.available_width())
+                .show_ui(ui, |ui| {
+                    for v in SYNC_BACKEND_OPTIONS {
+                        ui.selectable_value(&mut state.sync_backend, (*v).to_string(), *v);
+                    }
+                });
+
+            if let Some(msg) = state.error_msg.clone() {
+                ui.add_space(8.0);
+                ui.colored_label(egui::Color32::LIGHT_RED, msg);
+            }
+            if let Some(msg) = state.info_msg.clone() {
+                ui.add_space(8.0);
+                ui.colored_label(egui::Color32::LIGHT_GREEN, msg);
+            }
+
+            ui.add_space(8.0);
+            ui.horizontal(|ui| {
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Save").clicked() {
+                        do_save = true;
+                    }
+                    if ui.button("Close").clicked() {
+                        close = true;
+                    }
+                });
+            });
+        });
+
+    if !open_flag {
+        close = true;
+    }
+    if do_save {
+        state.save();
+    }
+    if close {
+        app.settings_panel = None;
+    }
+}

--- a/sapphire-journal-gui/src/settings.rs
+++ b/sapphire-journal-gui/src/settings.rs
@@ -1,0 +1,50 @@
+//! Persisted UI preferences (separate from `journals.toml`).
+//!
+//! Currently only records the last-opened journal so the app can resume
+//! straight into it on next start.  Lives at
+//! `$XDG_DATA_HOME/sapphire-journal/settings.toml`.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::Result;
+use crate::registry::JournalRegistry;
+
+/// On-disk user preferences for the GUI.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Settings {
+    /// `id` of the journal that was open when the app last exited.
+    #[serde(default)]
+    pub last_opened_journal_id: Option<Uuid>,
+}
+
+impl Settings {
+    /// `$XDG_DATA_HOME/sapphire-journal/settings.toml`
+    pub fn path() -> PathBuf {
+        JournalRegistry::data_dir().join("settings.toml")
+    }
+
+    /// Load the settings from disk, returning defaults if the file does not exist.
+    pub fn load() -> Result<Self> {
+        let path = Self::path();
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let contents = std::fs::read_to_string(&path)?;
+        let settings: Self = toml::from_str(&contents)?;
+        Ok(settings)
+    }
+
+    /// Persist the settings to disk.
+    pub fn save(&self) -> Result<()> {
+        let path = Self::path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let contents = toml::to_string_pretty(self)?;
+        std::fs::write(&path, contents)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

新しい `sapphire-journal-gui` クレート（**eframe 0.34 + egui 0.34**）を追加し、ジャーナルのデスクトップ GUI を「日常的に使える最低限」のところまで実装します。既存の `sapphire-journal-dioxus` は本 PR では残し、実運用で十分な手応えが取れてから別 PR で削除する想定です。

## Why egui

- **Single-binary distribution**: Dioxus が Linux で必要としていた `webkit2gtk` 依存を外せる
- **GUI はまだ初期段階**で、フレームワーク切替のコストが小さい
- **iOS** を理由に Dioxus を選んでいたが、eframe 側でも iOS（Issue [#3117](https://github.com/emilk/egui/issues/3117) / Discussion [#5434](https://github.com/emilk/egui/discussions/5434)）と Android（PR [#5318](https://github.com/emilk/egui/pull/5318)）が進行中
- Web/React 由来の immediate-mode 不適合な前提もない

## Features

- **ジャーナル管理**: 新規作成 / `git clone`（プログレス表示） / 既存ローカルパスの "Open Existing…" / type-to-confirm 削除、起動時に最後に開いたジャーナルを自動オープン、ヘッダのスイッチャーから別ジャーナルへ切替
- **エントリー一覧**: List / Tree ビュー切替、検索・期間・ソートのフィルタ、Tree ビューでのドラッグ&ドロップによる親子付け替え（自分の子孫への投下は禁止、上部のドロップゾーンでトップレベル化）
- **エントリー編集**: タイトル / タグ / Task / Event / 本文の編集と保存、保存時に `fix_entry` でリネームを反映、削除は確認ダイアログ越し
- **コンテキストメニュー**: エントリーの右クリックで「Add child entry」「Delete entry…」
- **同期**: `JournalState` をバックグラウンドで開いてキャッシュ＋git sync を定期実行、メニューから "Sync now" でも起動
- **設定パネル**: ジャーナル単位／ユーザー単位の設定編集
- **見た目**: Lucide アイコン同梱、CJK 文字化け対策に Noto Sans JP を同梱

## Implementation notes

- `eframe::App` は 0.34 の新 API（`logic` で event drain、`ui` で immediate-mode 描画）を使用
- 非同期 clone のプログレス: `tokio::spawn_blocking` で git2 を走らせ、`RemoteCallbacks::transfer_progress` から `Arc<Mutex<Option<f32>>>` に書き込み、UI スレッドが毎フレーム読んで `request_repaint_after` で再描画
- バックグラウンドタスクからの registry 変更は `mpsc::UnboundedChannel` 経由で UI スレッドに渡し、`App` が適用＋永続化する単一スレッドモデル
- Tree ビューの D&D は egui の `dnd_drag_source` を `Sense::click_and_drag()` でインライン化し、クリック選択とドラッグを両立
- `sapphire-journal/src/main.rs` の差分は main からマージした `fix(core)!: initialise AppContext at startup` 由来で、GUI 機能本体は `sapphire-journal-gui/` 配下に閉じています

## Out of scope (follow-up)

- `sapphire-journal-dioxus` クレートの削除（実運用での feature parity 確認後）
- iOS サポート（eframe 側の対応待ち）

## Test plan

- [x] `cargo build --workspace` がクリーンに通る
- [x] `cargo check -p sapphire-journal-gui` がクリーンに通る
- [x] Cargo.lock に `webkit2gtk` が混ざっていない
- [x] `cargo run -p sapphire-journal-gui` で起動、新規ジャーナル作成 → エントリー作成 → 編集 → 保存
- [x] List / Tree ビュー切替、Tree ビューで親子付け替え（D&D）
- [x] エントリー右クリックメニューから子エントリー追加 / 削除
- [x] 設定パネルから設定を編集して保存
- [ ] `cargo build -p sapphire-journal-gui --release && ldd target/release/sapphire-journal-gui | grep -i webkit` が空であること
- [ ] リモート設定のあるジャーナルで "Sync now" が動くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)