### PR TITLE
refactor: unify CLI and MCP entry-command internals

### DIFF
--- a/sapphire-journal-cli/src/commands/entry.rs
+++ b/sapphire-journal-cli/src/commands/entry.rs
@@ -2,14 +2,15 @@ use anyhow::{bail, Context, Result};
 use sapphire_journal_core::{
     cache,
     entry_ref::EntryRef,
-    journal::Journal,
     labels::EntryFlag,
-    ops::{self, EntryFields as CoreEntryFields, EntryFilter, EntryListItem, EntryTreeNode, FieldSelector, MatchFlag, SortField, SortOrder, UpdateOption},
-    period::{parse_datetime, parse_datetime_end, parse_period},
+    ops::{self, EntryFields as CoreEntryFields, EntryFilter, EntryListItem, EntryTreeNode, MatchFlag, UpdateOption},
+    period::{parse_datetime, parse_datetime_end},
     user_config::UserConfig,
     JournalState,
 };
 use sapphire_journal_core::{FtsQuery, VectorQuery};
+
+use crate::shared;
 
 use chrono::NaiveDateTime;
 use clap::{Args, Subcommand};
@@ -97,28 +98,26 @@ fn build_filter(args: &EntryFilterArgs) -> Result<EntryFilter> {
              or pass `--all-periods` to show all entries"
         );
     }
-    let parse = |s: &str| parse_period(s).map_err(anyhow::Error::msg);
-    Ok(EntryFilter {
-        period: args.period.as_deref().map(parse).transpose()?,
-        fields: {
-            let base = if args.active { FieldSelector::active() } else { FieldSelector::default() };
-            FieldSelector {
-                task_overdue:     base.task_overdue     || args.task_overdue,
-                task_in_progress: base.task_in_progress || args.task_in_progress,
-                task_unstarted:   base.task_unstarted   || args.task_unstarted,
-                event_span:       base.event_span       || args.event_span,
-                created_at:       base.created_at       || args.created_at,
-                updated_at:       base.updated_at       || args.updated_at,
-            }
-        },
-        task_status: args.task_status.clone().unwrap_or_default(),
-        tags: args.tags.clone().unwrap_or_default(),
-        sort_by: args.sort_by.as_deref()
-            .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
-            .transpose()?
-            .unwrap_or_default(),
-        sort_order: args.sort_order.parse::<SortOrder>().map_err(anyhow::Error::msg)?,
-    })
+    shared::filter::build_filter(shared::filter::FilterInputs::from(args))
+}
+
+impl<'a> From<&'a EntryFilterArgs> for shared::filter::FilterInputs<'a> {
+    fn from(a: &'a EntryFilterArgs) -> Self {
+        Self {
+            period: a.period.as_deref(),
+            active: a.active,
+            task_overdue: a.task_overdue,
+            task_in_progress: a.task_in_progress,
+            task_unstarted: a.task_unstarted,
+            event_span: a.event_span,
+            created_at: a.created_at,
+            updated_at: a.updated_at,
+            task_status: a.task_status.as_deref().unwrap_or(&[]),
+            tags: a.tags.as_deref().unwrap_or(&[]),
+            sort_by: a.sort_by.as_deref(),
+            sort_order: Some(a.sort_order.as_str()),
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -312,7 +311,7 @@ impl From<EntryFields> for CoreEntryFields {
 }
 
 pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
-    let state = open_state(journal_dir)?;
+    let state = shared::state::open_state(journal_dir)?;
 
     match cmd {
         EntryCommand::List { filter: filter_args, json, emoji, nerd } => {
@@ -359,16 +358,6 @@ pub fn run(journal_dir: Option<&Path>, cmd: EntryCommand) -> Result<()> {
             search(&state, &query, semantic, limit)
         }
     }
-}
-
-fn open_state(journal_dir: Option<&Path>) -> Result<JournalState> {
-    let journal = match journal_dir {
-        Some(dir) => Journal::from_root(dir.to_path_buf())
-            .context("not a sapphire-journal — run `sapphire-journal init` to initialize one"),
-        None => Journal::find()
-            .context("not in a sapphire-journal — run `sapphire-journal init` to initialize one"),
-    }?;
-    JournalState::open(journal).map_err(Into::into)
 }
 
 fn resolve_entry(state: &JournalState, entry: &str) -> Result<PathBuf> {
@@ -544,6 +533,7 @@ fn new(state: &JournalState, fields: EntryFields) -> Result<()> {
     if let Ok(conn) = state.open_conn() {
         let _ = cache::upsert_entry_from_path(&conn, &dest, state.retrieve_db());
     }
+    let _ = state.on_file_updated(&dest);
     println!("created: {}", dest.display());
     Ok(())
 }
@@ -562,13 +552,18 @@ fn edit(path: &Path, state: &JournalState) -> Result<()> {
     if !status.success() {
         bail!("editor exited with non-zero status");
     }
-    let final_path = match ops::fix_entry(path)? {
-        Some(new_path) => { println!("updated: {}", new_path.display()); new_path }
+    let renamed = ops::fix_entry(path)?;
+    let final_path = match &renamed {
+        Some(new_path) => { println!("updated: {}", new_path.display()); new_path.clone() }
         None           => { println!("updated: {}", path.display()); path.to_path_buf() }
     };
     if let Ok(conn) = state.open_conn() {
         let _ = cache::upsert_entry_from_path(&conn, &final_path, state.retrieve_db());
     }
+    if renamed.is_some() {
+        let _ = state.on_file_deleted(path);
+    }
+    let _ = state.on_file_updated(&final_path);
     Ok(())
 }
 
@@ -585,13 +580,18 @@ fn edit_new(state: &JournalState) -> Result<()> {
         bail!("editor exited with non-zero status");
     }
 
-    let final_path = match ops::fix_entry(&path)? {
-        Some(new_path) => { println!("created: {}", new_path.display()); new_path }
-        None           => { println!("created: {}", path.display()); path }
+    let renamed = ops::fix_entry(&path)?;
+    let final_path = match &renamed {
+        Some(new_path) => { println!("created: {}", new_path.display()); new_path.clone() }
+        None           => { println!("created: {}", path.display()); path.clone() }
     };
     if let Ok(conn) = state.open_conn() {
         let _ = cache::upsert_entry_from_path(&conn, &final_path, state.retrieve_db());
     }
+    if renamed.is_some() {
+        let _ = state.on_file_deleted(&path);
+    }
+    let _ = state.on_file_updated(&final_path);
     Ok(())
 }
 
@@ -620,11 +620,14 @@ fn set(state: &JournalState, path: &Path, fields: EntryFields, no_parent: bool) 
         core_fields.parent = UpdateOption::Clear;
     }
     let new_path_opt = ops::update_entry(path, &conn, core_fields)?;
-    let final_path = new_path_opt.as_deref().unwrap_or(path);
-    let _ = cache::upsert_entry_from_path(&conn, final_path, state.retrieve_db());
     if let Some(new_path) = new_path_opt {
+        let _ = cache::upsert_entry_from_path(&conn, &new_path, state.retrieve_db());
+        let _ = state.on_file_deleted(path);
+        let _ = state.on_file_updated(&new_path);
         println!("updated and renamed: {}", new_path.display());
     } else {
+        let _ = cache::upsert_entry_from_path(&conn, path, state.retrieve_db());
+        let _ = state.on_file_updated(path);
         println!("updated: {}", path.display());
     }
     Ok(())
@@ -650,12 +653,22 @@ fn check(state: &JournalState, entry: &str) -> Result<()> {
 fn fix(state: &JournalState, entry: &str) -> Result<()> {
     let path = resolve_entry(state, entry)?;
     match ops::fix_entry(&path)? {
-        Some(new_path) => println!(
-            "renamed: {} → {}",
-            path.file_name().unwrap_or_default().to_string_lossy(),
-            new_path.file_name().unwrap_or_default().to_string_lossy(),
-        ),
-        None => println!("ok: {} (already correct)", path.display()),
+        Some(new_path) => {
+            if let Ok(conn) = state.open_conn() {
+                let _ = cache::upsert_entry_from_path(&conn, &new_path, state.retrieve_db());
+            }
+            let _ = state.on_file_deleted(&path);
+            let _ = state.on_file_updated(&new_path);
+            println!(
+                "renamed: {} → {}",
+                path.file_name().unwrap_or_default().to_string_lossy(),
+                new_path.file_name().unwrap_or_default().to_string_lossy(),
+            );
+        }
+        None => {
+            let _ = state.on_file_updated(&path);
+            println!("ok: {} (already correct)", path.display());
+        }
     }
     Ok(())
 }
@@ -690,6 +703,7 @@ fn remove(state: &JournalState, entry: &str) -> Result<()> {
     if let Ok(conn) = state.open_conn() {
         let _ = cache::remove_from_cache(&conn, &path, state.retrieve_db());
     }
+    let _ = state.on_file_deleted(&path);
     println!("removed: {}", path.display());
     Ok(())
 }
@@ -699,15 +713,22 @@ fn remove(state: &JournalState, entry: &str) -> Result<()> {
 fn search(state: &JournalState, query: &str, semantic: bool, limit: usize) -> Result<()> {
     if semantic {
         // ── vector similarity search ──────────────────────────────────────────
+        state.sync()?;
         let user_cfg = UserConfig::load()?;
-        state.load_retrieve_backend(&user_cfg).map_err(anyhow::Error::msg)?;
-        state.load_embedder(&user_cfg).map_err(anyhow::Error::msg)?;
+        shared::state::bootstrap_embedder(state, &user_cfg)?;
         let embedder = state.embedder().ok_or_else(|| {
             anyhow::anyhow!(
                 "[cache.embedding] is required in ~/.config/sapphire-journal/config.toml \
                  for semantic search"
             )
         })?;
+
+        let pending = state.retrieve_db().vec_info()
+            .map(|vi| vi.pending_count)
+            .unwrap_or(0);
+        if pending > 0 && pending <= 50 {
+            let _ = state.retrieve_db().embed_pending(embedder, |_, _| {});
+        }
 
         let q = VectorQuery::new(query, embedder).limit(limit);
         let results = state.retrieve_db().search_similar(&q)

--- a/sapphire-journal-cli/src/commands/mcp.rs
+++ b/sapphire-journal-cli/src/commands/mcp.rs
@@ -6,13 +6,14 @@ use sapphire_journal_core::{
     cache,
     entry_ref::EntryRef,
     journal::Journal,
-    ops::{self, EntryFields, EntryFilter, EntryListItem, FieldSelector, SortField, SortOrder, UpdateOption},
+    ops::{self, EntryFields, EntryListItem, UpdateOption},
     parser::read_entry,
-    period::{parse_datetime, parse_datetime_end, parse_period},
     user_config::UserConfig,
     JournalState,
 };
 use tokio::time;
+
+use crate::shared;
 use rmcp::{
     Peer, RoleServer, ServerHandler, ServiceExt,
     handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
@@ -78,15 +79,9 @@ impl ArchelonServer {
             let state = JournalState::open(journal)?;
             let config = UserConfig::load()?;
             if config.cache.retrieve.embedding.as_ref().map(|e| e.enabled).unwrap_or(false) {
-                // block_in_place suspends the current tokio worker and lets us
-                // call block_on without nesting runtimes.  Requires the
-                // multi-thread runtime (the default for #[tokio::main]).
-                tokio::task::block_in_place(|| {
-                    tokio::runtime::Handle::current().block_on(async {
-                        state.load_retrieve_backend_async(&config).await?;
-                        state.load_embedder_async(&config).await
-                    })
-                })?;
+                // block_in_place lets the embedder/lancedb init block without
+                // starving other tokio tasks on the multi-thread runtime.
+                tokio::task::block_in_place(|| shared::state::bootstrap_embedder(&state, &config))?;
             }
             *guard = Some(state);
         }
@@ -105,12 +100,7 @@ impl ArchelonServer {
         state.sync()?;
         let config = UserConfig::load()?;
         if config.cache.retrieve.embedding.as_ref().map(|e| e.enabled).unwrap_or(false) {
-            tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async {
-                    state.load_retrieve_backend_async(&config).await?;
-                    state.load_embedder_async(&config).await
-                })
-            })?;
+            tokio::task::block_in_place(|| shared::state::bootstrap_embedder(&state, &config))?;
         }
         let info = state.cache_info()?;
         let root = state.journal.root.display().to_string();
@@ -298,60 +288,39 @@ fn parse_entry_fields(
     event_start: Option<&str>,
     event_end: Option<&str>,
 ) -> anyhow::Result<EntryFields> {
+    use shared::fields::{parse_optional_datetime, parse_optional_datetime_end, parse_tags_csv};
     Ok(EntryFields {
         title: None,
         body: None,
         parent: UpdateOption::Unchanged,
         slug,
-        tags: tags.as_deref().map(|s| {
-            s.split(',')
-                .map(|t| t.trim().to_owned())
-                .filter(|t| !t.is_empty())
-                .collect()
-        }),
-        task_due: task_due
-            .map(|s| parse_datetime_end(s).map_err(anyhow::Error::msg))
-            .transpose()?,
+        tags: parse_tags_csv(tags.as_deref()),
+        task_due: parse_optional_datetime_end(task_due)?,
         task_status,
-        task_started_at: task_started_at
-            .map(|s| parse_datetime(s).map_err(anyhow::Error::msg))
-            .transpose()?,
-        task_closed_at: task_closed_at
-            .map(|s| parse_datetime(s).map_err(anyhow::Error::msg))
-            .transpose()?,
-        event_start: event_start
-            .map(|s| parse_datetime(s).map_err(anyhow::Error::msg))
-            .transpose()?,
-        event_end: event_end
-            .map(|s| parse_datetime_end(s).map_err(anyhow::Error::msg))
-            .transpose()?,
+        task_started_at: parse_optional_datetime(task_started_at)?,
+        task_closed_at: parse_optional_datetime(task_closed_at)?,
+        event_start: parse_optional_datetime(event_start)?,
+        event_end: parse_optional_datetime_end(event_end)?,
     })
 }
 
-fn build_filter(p: &EntryListParams) -> anyhow::Result<EntryFilter> {
-    let parse = |s: &str| parse_period(s).map_err(anyhow::Error::msg);
-    let base = if p.active.unwrap_or(false) { FieldSelector::active() } else { FieldSelector::default() };
-    Ok(EntryFilter {
-        period: p.period.as_deref().map(parse).transpose()?,
-        fields: FieldSelector {
-            task_overdue:     base.task_overdue     || p.task_overdue.unwrap_or(false),
-            task_in_progress: base.task_in_progress || p.task_in_progress.unwrap_or(false),
-            task_unstarted:   base.task_unstarted   || p.task_unstarted.unwrap_or(false),
-            event_span:       base.event_span       || p.event_span.unwrap_or(false),
-            created_at:       base.created_at       || p.created_at.unwrap_or(false),
-            updated_at:       base.updated_at       || p.updated_at.unwrap_or(false),
-        },
-        task_status: p.task_status.clone().unwrap_or_default(),
-        tags: p.tags.clone().unwrap_or_default(),
-        sort_by: p.sort_by.as_deref()
-            .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
-            .transpose()?
-            .unwrap_or_default(),
-        sort_order: p.sort_order.as_deref()
-            .map(|s| s.parse::<SortOrder>().map_err(anyhow::Error::msg))
-            .transpose()?
-            .unwrap_or_default(),
-    })
+impl<'a> From<&'a EntryListParams> for shared::filter::FilterInputs<'a> {
+    fn from(p: &'a EntryListParams) -> Self {
+        Self {
+            period: p.period.as_deref(),
+            active: p.active.unwrap_or(false),
+            task_overdue: p.task_overdue.unwrap_or(false),
+            task_in_progress: p.task_in_progress.unwrap_or(false),
+            task_unstarted: p.task_unstarted.unwrap_or(false),
+            event_span: p.event_span.unwrap_or(false),
+            created_at: p.created_at.unwrap_or(false),
+            updated_at: p.updated_at.unwrap_or(false),
+            task_status: p.task_status.as_deref().unwrap_or(&[]),
+            tags: p.tags.as_deref().unwrap_or(&[]),
+            sort_by: p.sort_by.as_deref(),
+            sort_order: p.sort_order.as_deref(),
+        }
+    }
 }
 
 // ── tool implementations ──────────────────────────────────────────────────────
@@ -430,7 +399,7 @@ impl ArchelonServer {
         included. task_status and tags are independent AND filters.")]
     fn entry_list(&self, Parameters(p): Parameters<EntryListParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
-            let filter = build_filter(&p)?;
+            let filter = shared::filter::build_filter(shared::filter::FilterInputs::from(&p))?;
             let has_filter = filter.has_any_filter();
             let entries = self.with_state(|s| ops::list_entries(s, &filter).map_err(Into::into))?;
             let records: Vec<EntryListItem> = entries
@@ -450,7 +419,7 @@ impl ArchelonServer {
         Each node contains an `id`, `title`, `task`, `tags`, and a `children` array of nested nodes.")]
     fn entry_tree(&self, Parameters(p): Parameters<EntryTreeParams>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
-            let filter = build_filter(&p)?;
+            let filter = shared::filter::build_filter(shared::filter::FilterInputs::from(&p))?;
             let entries = self.with_state(|s| ops::list_entries(s, &filter).map_err(Into::into))?;
             let roots = ops::build_entry_tree(entries);
             Ok(serde_json::to_string_pretty(&roots)?)

--- a/sapphire-journal-cli/src/main.rs
+++ b/sapphire-journal-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod shared;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/sapphire-journal-cli/src/shared/fields.rs
+++ b/sapphire-journal-cli/src/shared/fields.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+use chrono::NaiveDateTime;
+use sapphire_journal_core::period::{parse_datetime, parse_datetime_end};
+
+/// Split a comma-separated tag string into a `Vec<String>`, trimming and dropping empties.
+/// Returns `None` when the input is `None`, preserving the "leave tags untouched" semantics.
+/// Used by MCP where tags arrive as a string; CLI uses clap's value_delimiter and skips this.
+pub fn parse_tags_csv(tags: Option<&str>) -> Option<Vec<String>> {
+    tags.map(|s| {
+        s.split(',')
+            .map(|t| t.trim().to_owned())
+            .filter(|t| !t.is_empty())
+            .collect()
+    })
+}
+
+pub fn parse_optional_datetime(s: Option<&str>) -> Result<Option<NaiveDateTime>> {
+    s.map(|s| parse_datetime(s).map_err(anyhow::Error::msg)).transpose()
+}
+
+pub fn parse_optional_datetime_end(s: Option<&str>) -> Result<Option<NaiveDateTime>> {
+    s.map(|s| parse_datetime_end(s).map_err(anyhow::Error::msg)).transpose()
+}

--- a/sapphire-journal-cli/src/shared/filter.rs
+++ b/sapphire-journal-cli/src/shared/filter.rs
@@ -1,0 +1,51 @@
+use anyhow::Result;
+use sapphire_journal_core::{
+    ops::{EntryFilter, FieldSelector, SortField, SortOrder},
+    period::parse_period,
+};
+
+/// Frontend-neutral inputs for [`build_filter`].
+///
+/// Both the CLI's clap-derived `EntryFilterArgs` and the MCP's serde-derived
+/// `EntryListParams` convert into this struct via `From`, so the actual filter
+/// construction lives in one place.
+pub struct FilterInputs<'a> {
+    pub period: Option<&'a str>,
+    pub active: bool,
+    pub task_overdue: bool,
+    pub task_in_progress: bool,
+    pub task_unstarted: bool,
+    pub event_span: bool,
+    pub created_at: bool,
+    pub updated_at: bool,
+    pub task_status: &'a [String],
+    pub tags: &'a [String],
+    pub sort_by: Option<&'a str>,
+    pub sort_order: Option<&'a str>,
+}
+
+pub fn build_filter(inputs: FilterInputs<'_>) -> Result<EntryFilter> {
+    let parse_p = |s: &str| parse_period(s).map_err(anyhow::Error::msg);
+    let base = if inputs.active { FieldSelector::active() } else { FieldSelector::default() };
+    Ok(EntryFilter {
+        period: inputs.period.map(parse_p).transpose()?,
+        fields: FieldSelector {
+            task_overdue:     base.task_overdue     || inputs.task_overdue,
+            task_in_progress: base.task_in_progress || inputs.task_in_progress,
+            task_unstarted:   base.task_unstarted   || inputs.task_unstarted,
+            event_span:       base.event_span       || inputs.event_span,
+            created_at:       base.created_at       || inputs.created_at,
+            updated_at:       base.updated_at       || inputs.updated_at,
+        },
+        task_status: inputs.task_status.to_vec(),
+        tags: inputs.tags.to_vec(),
+        sort_by: inputs.sort_by
+            .map(|s| s.parse::<SortField>().map_err(anyhow::Error::msg))
+            .transpose()?
+            .unwrap_or_default(),
+        sort_order: inputs.sort_order
+            .map(|s| s.parse::<SortOrder>().map_err(anyhow::Error::msg))
+            .transpose()?
+            .unwrap_or_default(),
+    })
+}

--- a/sapphire-journal-cli/src/shared/mod.rs
+++ b/sapphire-journal-cli/src/shared/mod.rs
@@ -1,0 +1,3 @@
+pub mod fields;
+pub mod filter;
+pub mod state;

--- a/sapphire-journal-cli/src/shared/state.rs
+++ b/sapphire-journal-cli/src/shared/state.rs
@@ -1,0 +1,29 @@
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use sapphire_journal_core::{journal::Journal, user_config::UserConfig, JournalState};
+
+/// Open a `JournalState` from an explicit directory or by walking up from the CWD.
+///
+/// Shared by CLI's entry commands and MCP's `journal_open` flow.
+pub fn open_state(journal_dir: Option<&Path>) -> Result<JournalState> {
+    let journal = match journal_dir {
+        Some(dir) => Journal::from_root(dir.to_path_buf())
+            .context("not a sapphire-journal — run `sapphire-journal init` to initialize one"),
+        None => Journal::find()
+            .context("not in a sapphire-journal — run `sapphire-journal init` to initialize one"),
+    }?;
+    JournalState::open(journal).map_err(Into::into)
+}
+
+/// Initialise the vector backend and embedder when configured.
+///
+/// This calls the sync variants on `JournalState`; the underlying lancedb store
+/// uses `block_in_place` internally so this is also safe to call from inside a
+/// tokio multi-thread runtime task (MCP wraps the call in `block_in_place` to
+/// avoid blocking other tasks during the initial model download).
+pub fn bootstrap_embedder(state: &JournalState, config: &UserConfig) -> Result<()> {
+    state.load_retrieve_backend(config).map_err(anyhow::Error::msg)?;
+    state.load_embedder(config).map_err(anyhow::Error::msg)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Move duplicated `build_filter` / `EntryFields` parsing / `open_state` / embedder bootstrap shared between `entry.rs` and `mcp.rs` into a new `sapphire-journal-cli/src/shared/` module.
- Bring CLI mutations in line with MCP: `entry new` / `edit` / `edit_new` / `modify` / `fix` / `remove` now notify the sync backend via `on_file_updated` / `on_file_deleted` so git-sync sees CLI-driven changes.
- Fix latent `entry fix` cache bug — after a rename the cache used to keep pointing at the old filename. Now upserts the new path.
- `entry search --semantic` syncs the cache and auto-embeds up to 50 pending chunks before vector search, matching MCP so freshly created entries appear in results.

Closes #213.

## Test plan
- [x] `cargo build -p sapphire-journal-cli`
- [x] `cargo test --workspace` — all suites pass
- [ ] Smoke test against a scratch journal (`sapphire-journal init /tmp/sj-verify`):
  - [ ] `entry new` → file + cache row + git stage when sync is on
  - [ ] `entry list <PERIOD>` / `--json` produce identical output to pre-refactor
  - [ ] `entry list` without `PERIOD` and without `--all-periods` still bails with the same message
  - [ ] `entry modify @<id>` rename reflects in both cache and sync
  - [ ] `entry fix @<id>` on a corrupted filename — cache row points at new name (previously broken)
  - [ ] `entry remove @<id>` → file + cache row gone, git shows deletion staged
  - [ ] `entry search "..." --semantic` immediately after creating an entry returns it (auto-embed)
  - [ ] MCP `entry_list` / `entry_new` / `entry_modify` / `entry_search` JSON identical to pre-refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)