### PR TITLE
chore: use short tag names for release-plz to preserve cli-v history

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -3,7 +3,7 @@ name: Release CLI Binaries
 on:
   push:
     tags:
-      - 'sapphire-journal-cli-v*'
+      - 'cli-v*'
 
 jobs:
   build:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,15 +5,23 @@ git_tag_enable = true
 
 [[package]]
 name = "sapphire-journal-core"
+git_tag_name = "core-v{{ version }}"
+git_release_name = "core-v{{ version }}"
 
 [[package]]
 name = "sapphire-journal-cli"
+git_tag_name = "cli-v{{ version }}"
+git_release_name = "cli-v{{ version }}"
 
 [[package]]
 name = "sapphire-journal-mcp"
+git_tag_name = "mcp-v{{ version }}"
+git_release_name = "mcp-v{{ version }}"
 
 [[package]]
 name = "sapphire-journal-desktop"
+git_tag_name = "desktop-v{{ version }}"
+git_release_name = "desktop-v{{ version }}"
 
 [[package]]
 name = "sapphire-journal-dioxus"


### PR DESCRIPTION
## Summary
- Configure release-plz to emit short-form tags and GitHub Release names: `core-v{version}`, `cli-v{version}`, `mcp-v{version}`, `desktop-v{version}` (instead of release-plz's default `{package}-v{version}`)
- Revert `release-cli.yml` tag trigger from `sapphire-journal-cli-v*` back to `cli-v*` to match

## Why
The existing `cli-v0.11.1` tag becomes a natural baseline for the next CLI release once we use this format. Without it, release-plz would walk all of the package's git history on its first run and likely propose an oversized version bump. With the short-tag format, only commits since `cli-v0.11.1` are considered for the CLI bump.

core / mcp / desktop have no prior tags either way, so for them release-plz will fall back to the version in Cargo.toml (0.11.1 for core/mcp, 0.1.0 for desktop) as the baseline.

## Test plan
- [ ] After merge: the first release-plz Release PR proposes sensible bumps (sapphire-journal-cli's diff scoped to commits after `cli-v0.11.1`)
- [ ] Merging the Release PR creates tags in the form `cli-v*`, `core-v*`, `mcp-v*`, `desktop-v*`
- [ ] The `cli-v*` tag push triggers `release-cli.yml` and `sajo` binaries are attached to the GitHub Release