### PR TITLE
fix: update release-plz action reference to release-plz/action@v0.5.129

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: MarcoIeni/release-plz-action@v0
+      - uses: release-plz/action@v0.5.129
         with:
           command: release
         env:
@@ -43,7 +43,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: MarcoIeni/release-plz-action@v0
+      - uses: release-plz/action@v0.5.129
         with:
           command: release-pr
         env:


### PR DESCRIPTION
## Summary
- The release-plz action moved from `MarcoIeni/release-plz-action` to `release-plz/action`
- The new repository does not publish a floating `@v0` tag — only specific `v0.5.x` versions (the v0.5 line has been stable for years)
- Pin to the latest stable `v0.5.129`; dependabot can bump it from here

## Fixes
Previous workflow runs failed with:
```
Error: Unable to resolve action `marcoieni/release-plz-action@v0`, unable to find version `v0`
```

## Test plan
- [ ] After merge: `Release-plz` workflow on main resolves the action successfully and opens a Release PR