### PR TITLE
fix: enable crates.io publishing for sapphire-journal-desktop

### DIFF
--- a/sapphire-journal-desktop/Cargo.toml
+++ b/sapphire-journal-desktop/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 description.workspace = true
 license = "GPL-3.0-or-later"
 repository.workspace = true
-publish = false
 
 [dependencies]
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.11.1" }


### PR DESCRIPTION
## Summary
- Drop `publish = false` from `sapphire-journal-desktop/Cargo.toml` so the desktop crate is publishable to crates.io
- Resolves the release-plz config mismatch that was blocking the workflow:
  ```
  ERROR Package `sapphire-journal-desktop` has `publish = false` or `publish = []` in the Cargo.toml, but it has `publish = true` in the release-plz configuration.
  ```

## Why publish the GUI to crates.io
Publishing GUI/binary apps to crates.io is a soft norm rather than a strict rule — many notable Rust apps (helix-term, bottom, zellij, gitui, bat, eza, rerun-cli, …) do publish. For a developer-oriented journaling app whose users likely have a Rust toolchain installed already, `cargo install sapphire-journal-desktop` is a real convenience.

## Follow-ups (planned around the actual v0.1.0 desktop release)
- Add `sapphire-journal-desktop/README.md` for the crates.io page
- Add a desktop binary release workflow (cross-platform builds attached to the GitHub Release on `desktop-v*` tag push) for non-Rust users

Neither blocks publishing — README missing is just a bare crate page (recoverable on next publish), and binaries are an independent distribution channel.

## Test plan
- [ ] After merge: release-plz workflow on main completes without the publish mismatch error and opens a Release PR