### PR TITLE
chore: disable release-plz auto-trigger until initial publishes are done

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,10 +4,12 @@ permissions:
   pull-requests: write
   contents: write
 
+# Auto-trigger disabled until the missing crates have been manually
+# published to crates.io for the first time (see issue #225).
+# Re-enable by restoring `push: branches: [main]` once initial
+# publishes are done.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   release-plz-release:


### PR DESCRIPTION
## Summary
- Switch the release-plz workflow trigger from `push: branches: [main]` to `workflow_dispatch:` so it does not run automatically
- The workflow is still available for manual runs (Actions tab → Release-plz → Run workflow)

## Why
release-plz fails on every push because three workspace crates have a tag/registry mismatch it cannot resolve on its own:
- `sapphire-journal-cli` has tag `cli-v0.11.1` but is not on crates.io (it was renamed from the legacy `sapphire-journal` crate)
- `sapphire-journal-mcp` and `sapphire-journal-desktop` are new crates that have never been published

Running release-plz before these initial publishes happen produces noisy failures and an empty Release PR. Disabling the auto-trigger stops the noise without ripping out the configuration.

## Next steps
Tracked in #225:
1. Manually publish missing crates to crates.io (mcp → cli → desktop)
2. Create baseline `core-v*`, `mcp-v*`, `desktop-v*` tags
3. Restore `push: branches: [main]` in this workflow

## Test plan
- [ ] After merge: no more failing `Release-plz` runs on pushes to main
- [ ] Workflow is still runnable manually via `workflow_dispatch`