### PR TITLE
refactor(cli): rename binary from `sajo` to `sapphire-journal`

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -11,17 +11,17 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            binary: sajo
-            asset_name: sajo-linux-x86_64
+            binary: sapphire-journal
+            asset_name: sapphire-journal-linux-x86_64
           - os: macos-latest
-            binary: sajo
-            asset_name: sajo-macos-aarch64
+            binary: sapphire-journal
+            asset_name: sapphire-journal-macos-aarch64
           - os: windows-latest
-            binary: sajo.exe
-            asset_name: sajo-windows-x86_64.exe
+            binary: sapphire-journal.exe
+            asset_name: sapphire-journal-windows-x86_64.exe
           - os: ubuntu-24.04-arm
-            binary: sajo
-            asset_name: sajo-linux-aarch64
+            binary: sapphire-journal
+            asset_name: sapphire-journal-linux-aarch64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -14,7 +14,7 @@
     {
       "label": "Copy binary to sapphire-journal-vscode/bin",
       "type": "shell",
-      "command": "mkdir -p sapphire-journal-vscode/bin && cp target/debug/sajo sapphire-journal-vscode/bin/sajo",
+      "command": "mkdir -p sapphire-journal-vscode/bin && cp target/debug/sapphire-journal sapphire-journal-vscode/bin/sapphire-journal",
       "options": {
         "cwd": "${workspaceFolder}"
       },

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Platform-specific VSIX files (with the CLI binary bundled) are also on the [Rele
 ```
 sapphire-journal/
 ├── sapphire-journal-core/     # Data model, Markdown parser/serializer, SQLite cache
-├── sapphire-journal-cli/      # CLI binary (sajo)
+├── sapphire-journal-cli/      # CLI binary (sapphire-journal)
 ├── sapphire-journal-mcp/      # MCP server binary (sapphire-journal-mcp)
 ├── sapphire-journal-desktop/  # Desktop GUI (egui)
 └── sapphire-journal-vscode/   # VS Code extension

--- a/sapphire-journal-cli/Cargo.toml
+++ b/sapphire-journal-cli/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["command-line-utilities", "text-processing"]
 keywords = ["markdown", "task-management", "notes", "cli", "mcp"]
 
 [[bin]]
-name = "sajo"
+name = "sapphire-journal"
 path = "src/main.rs"
 
 [features]

--- a/sapphire-journal-cli/README.md
+++ b/sapphire-journal-cli/README.md
@@ -36,7 +36,7 @@ cargo install --path .
 ### Initialize a journal
 
 ```bash
-sajo init [PATH]
+sapphire-journal init [PATH]
 ```
 
 Creates `.sapphire-journal/config.toml` with the detected local timezone and `.sapphire-journal/.gitignore`.
@@ -45,7 +45,7 @@ Creates `.sapphire-journal/config.toml` with the detected local timezone and `.s
 
 ```bash
 # Override journal root (also settable via SAPPHIRE_JOURNAL_DIR env var)
-sajo --journal-dir /path/to/journal <command>
+sapphire-journal --journal-dir /path/to/journal <command>
 ```
 
 ### Entry commands
@@ -53,7 +53,7 @@ sajo --journal-dir /path/to/journal <command>
 #### Create a new entry
 
 ```bash
-sajo entry new --title <TITLE> [--body "body text"] [OPTIONS]
+sapphire-journal entry new --title <TITLE> [--body "body text"] [OPTIONS]
 ```
 
 Options:
@@ -68,7 +68,7 @@ The filename is auto-generated as `{year}/{grain-id}_{slug}.md`.
 #### Create and edit in $EDITOR
 
 ```bash
-sajo entry edit --new
+sapphire-journal entry edit --new
 ```
 
 Opens `$EDITOR` (`$VISUAL` → `$EDITOR` → `vi`) with a pre-filled frontmatter template. On save, the filename is adjusted to match the title.
@@ -76,13 +76,13 @@ Opens `$EDITOR` (`$VISUAL` → `$EDITOR` → `vi`) with a pre-filled frontmatter
 #### List entries
 
 ```bash
-sajo entry list [PATH] [OPTIONS]
+sapphire-journal entry list [PATH] [OPTIONS]
 ```
 
 Timestamp filters (OR'd across fields):
 
 ```bash
-sajo entry list [PERIOD]      # positional PERIOD applies to all timestamp fields
+sapphire-journal entry list [PERIOD]      # positional PERIOD applies to all timestamp fields
 --task-due PERIOD             # filter by task due date
 --event-span PERIOD           # filter by event span overlap (in-progress events included)
 --created-at PERIOD           # filter by created_at
@@ -124,7 +124,7 @@ Output:
 #### Display entries as a tree
 
 ```bash
-sajo entry tree [PATH] [OPTIONS]
+sapphire-journal entry tree [PATH] [OPTIONS]
 ```
 
 Displays entries in a parent-child hierarchy based on `parent_id` in frontmatter.
@@ -137,13 +137,13 @@ Supports the same filter and sort options as `entry list`.
 #### Show an entry
 
 ```bash
-sajo entry show <file-or-id>
+sapphire-journal entry show <file-or-id>
 ```
 
 #### Edit an entry
 
 ```bash
-sajo entry edit <file-or-id>
+sapphire-journal entry edit <file-or-id>
 ```
 
 Opens the entry in `$EDITOR`.
@@ -151,10 +151,10 @@ Opens the entry in `$EDITOR`.
 #### Update frontmatter fields
 
 ```bash
-sajo entry modify <file-or-id> --title "New title"
-sajo entry modify <file-or-id> --tags work,backend
-sajo entry modify <file-or-id> --tags          # clear all tags
-sajo entry modify <file-or-id> --task-status done
+sapphire-journal entry modify <file-or-id> --title "New title"
+sapphire-journal entry modify <file-or-id> --tags work,backend
+sapphire-journal entry modify <file-or-id> --tags          # clear all tags
+sapphire-journal entry modify <file-or-id> --task-status done
 ```
 
 When `--task-status` is set to `done`, `cancelled`, or `archived`, `closed_at` is set automatically.
@@ -162,22 +162,22 @@ When `--task-status` is set to `done`, `cancelled`, or `archived`, `closed_at` i
 #### Check and fix filename
 
 ```bash
-sajo entry check <file-or-id>   # report any filename/frontmatter mismatches
-sajo entry fix <file-or-id>     # rename file to match frontmatter
+sapphire-journal entry check <file-or-id>   # report any filename/frontmatter mismatches
+sapphire-journal entry fix <file-or-id>     # rename file to match frontmatter
 ```
 
 #### Remove an entry
 
 ```bash
-sajo entry remove <file-or-id>
+sapphire-journal entry remove <file-or-id>
 ```
 
 ### Cache commands
 
 ```bash
-sajo cache info       # show cache status and statistics
-sajo cache sync       # incrementally update the cache
-sajo cache rebuild    # drop and rebuild the cache from scratch
+sapphire-journal cache info       # show cache status and statistics
+sapphire-journal cache sync       # incrementally update the cache
+sapphire-journal cache rebuild    # drop and rebuild the cache from scratch
 ```
 
 ### DATETIME format

--- a/sapphire-journal-cli/install.sh
+++ b/sapphire-journal-cli/install.sh
@@ -3,7 +3,7 @@ set -eu
 
 REPO="fluo10/sapphire-journal"
 INSTALL_DIR="${HOME}/.local/bin"
-BINARY="sajo"
+BINARY="sapphire-journal"
 
 case "$(uname -s)" in
   Linux*)  OS="linux" ;;


### PR DESCRIPTION
## Summary
- Renames the CLI binary produced by `sapphire-journal-cli` from `sajo` to `sapphire-journal`.
- Updates the release workflow asset names, the `install.sh` script, the CLI README usage examples, and the local VS Code dev task accordingly.
- CHANGELOG entries and the VS Code extension's deprecated `binaryPath` setting are intentionally left untouched — they describe historical state for users who may still have the old `sajo` binary on disk.

## Rationale
The CLI's primary role is the MCP transport for AI agents and a verification surface for AI-edited content; the human-facing UI is the GUI. Optimizing the binary name for typing has little payoff and the `sajo` abbreviation hurts discoverability. Using the full name also lines up with the sibling `sapphire-ledger` repo, which is renaming its CLI binary in parallel (its previous abbreviation `sale` collided with a common English word).

## Test plan
- [x] `cargo build -p sapphire-journal-cli` produces `target/debug/sapphire-journal`
- [x] `target/debug/sapphire-journal --help` shows the expected help text
- [ ] Release workflow produces `sapphire-journal-<os>-<arch>` artifacts on next tag
- [ ] `install.sh` downloads the renamed asset and installs `~/.local/bin/sapphire-journal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)