### PR TITLE
fix(desktop): include overdue and in-progress tasks in Period filter

### DIFF
--- a/sapphire-journal-desktop/src/screens/journal_home.rs
+++ b/sapphire-journal-desktop/src/screens/journal_home.rs
@@ -951,7 +951,7 @@ fn filter_and_sort(home: &HomeState) -> Vec<EntryHeader> {
         if let Ok(period) = parse_period(home.period.trim()) {
             let filter = EntryFilter {
                 period: Some(period),
-                fields: FieldSelector::default(),
+                fields: FieldSelector::active(),
                 task_status: Vec::new(),
                 tags: Vec::new(),
                 sort_by: CoreSortField::Unsorted,


### PR DESCRIPTION
## Summary
- Home screen's Period filter was passing `FieldSelector::default()` (all flags off), so selecting **Today** (or any preset) only matched entries via `event_span` / `created_at` / `updated_at`.
- Overdue and in-progress tasks were silently excluded — counterintuitive for a Bullet Journal-style daily log. If no entry happened to be created/updated/eventing today, the list looked empty.
- Switch to `FieldSelector::active()`, which mirrors the CLI's `--active` flag and additionally evaluates `task_overdue` + `task_in_progress` against the period.

## Test plan
- [ ] `cargo check -p sapphire-journal-desktop` (passes locally)
- [ ] Open desktop app, set Period = Today, confirm overdue and in-progress tasks appear alongside today's created/updated/event entries
- [ ] Verify other presets (this_week, this_month, etc.) still narrow as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)