### PR TITLE
feat(desktop): calendar period picker + date-picker popups

### DIFF
--- a/sapphire-journal-desktop/src/app.rs
+++ b/sapphire-journal-desktop/src/app.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use chrono::NaiveDate;
 use eframe::egui;
 use grain_id::GrainId;
 use sapphire_journal_core::{JournalState, entry::EntryHeader, user_config::UserConfig};
@@ -147,8 +148,16 @@ pub struct HomeState {
 
     // ── Sidebar filter / sort state ─────────────────────────────────────────
     pub filter_text: String,
-    /// Period preset (empty = all). One of "" | "today" | "yesterday" | ...
+    /// Active period filter, serialised as a [`sapphire_journal_core::period`] string.
+    /// Empty = no filter (all entries). Day click writes `YYYY-MM-DD`, week / month
+    /// clicks write `YYYY-MM-DD/YYYY-MM-DD`, the calendar's "Today" shortcut writes
+    /// `today`.
     pub period: String,
+    /// The month currently displayed in the home-screen calendar widget.  Mutated
+    /// by the calendar's ◀ / ▶ arrows and reset to today by the "Today" shortcut.
+    pub calendar_cursor: NaiveDate,
+    /// Whether the home-screen calendar is visible (toggled by its caret).
+    pub show_calendar: bool,
     /// Sort field. One of "updated_at" | "created_at" | "title" | "id"
     /// | "task_due" | "event_start".
     pub sort_by: String,
@@ -176,6 +185,8 @@ impl HomeState {
             show_filters: false,
             filter_text: String::new(),
             period: String::new(),
+            calendar_cursor: chrono::Local::now().date_naive(),
+            show_calendar: true,
             sort_by: "updated_at".to_string(),
             sort_order: "desc".to_string(),
             confirm_delete_entry: false,

--- a/sapphire-journal-desktop/src/main.rs
+++ b/sapphire-journal-desktop/src/main.rs
@@ -10,6 +10,7 @@ mod icons;
 mod registry;
 mod screens;
 mod settings;
+mod widgets;
 
 use app::App;
 

--- a/sapphire-journal-desktop/src/screens/journal_home.rs
+++ b/sapphire-journal-desktop/src/screens/journal_home.rs
@@ -1,6 +1,7 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+use chrono::{Duration, NaiveDate};
 use eframe::egui;
 use grain_id::GrainId;
 use uuid::Uuid;
@@ -16,11 +17,15 @@ use sapphire_journal_core::{
         remove_entry, update_entry,
     },
     parser::{read_entry, write_entry},
-    period::parse_period,
+    period::{Period, parse_period},
 };
 
 use crate::app::{App, AppState, EditorState, HomeState, ViewMode};
 use crate::icons;
+use crate::widgets::date_picker::date_picker_button;
+use crate::widgets::month_grid::{
+    self, MonthGrid, Selection, format_period_range, month_bounds, week_bounds,
+};
 
 pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
     // ── Ensure HomeState matches the requested journal ────────────────────
@@ -87,6 +92,11 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
         });
 
     egui::CentralPanel::default().show_inside(ui, |ui| {
+        egui::Panel::top("home_calendar")
+            .resizable(false)
+            .show_inside(ui, |ui| {
+                draw_home_calendar(app, ui);
+            });
         draw_editor_panel(app, ui);
     });
 
@@ -209,18 +219,6 @@ fn draw_sidebar(app: &mut App, ui: &mut egui::Ui) {
     if home.show_filters {
         ui.add_space(6.0);
 
-        // Filters: period + sort
-        ui.label("Period");
-        egui::ComboBox::from_id_salt("home_period")
-            .selected_text(period_label(&home.period))
-            .width(ui.available_width())
-            .show_ui(ui, |ui| {
-                for (value, label) in PERIOD_OPTIONS {
-                    ui.selectable_value(&mut home.period, (*value).to_string(), *label);
-                }
-            });
-
-        ui.add_space(4.0);
         ui.label("Sort by");
         egui::ComboBox::from_id_salt("home_sort_by")
             .selected_text(sort_label(&home.sort_by))
@@ -707,6 +705,123 @@ fn draw_entry_row(
     resp
 }
 
+// ── Home calendar (period picker) ────────────────────────────────────────────
+
+/// Renders the calendar above the editor.  Day / week / month clicks set
+/// `home.period` to a value `parse_period` understands.
+fn draw_home_calendar(app: &mut App, ui: &mut egui::Ui) {
+    let home = match app.home.as_mut() {
+        Some(h) => h,
+        None => return,
+    };
+
+    ui.add_space(2.0);
+    ui.horizontal(|ui| {
+        let caret = if home.show_calendar { "▾" } else { "▸" };
+        if ui
+            .add(egui::Button::new(format!("{caret} Calendar")).frame(false))
+            .clicked()
+        {
+            home.show_calendar = !home.show_calendar;
+        }
+        ui.weak(period_summary(&home.period));
+    });
+
+    if !home.show_calendar {
+        return;
+    }
+
+    // Pre-compute Bullet Journal-style entry counts for every cell on the
+    // displayed grid (6 weeks × 7 days, including spillover from adjacent
+    // months).  Mirrors the filter applied in `filter_and_sort` so the
+    // badge dots match what the user will see after clicking.
+    let grid_start = grid_start_for_month(home.calendar_cursor);
+    let mut counts: HashMap<NaiveDate, usize> = HashMap::new();
+    for offset in 0..42 {
+        let date = grid_start + Duration::days(offset);
+        let period = Period::Range(
+            date.and_hms_opt(0, 0, 0).unwrap(),
+            date.and_hms_opt(23, 59, 59).unwrap(),
+        );
+        let filter = EntryFilter {
+            period: Some(period),
+            fields: FieldSelector::active(),
+            task_status: Vec::new(),
+            tags: Vec::new(),
+            sort_by: CoreSortField::Unsorted,
+            sort_order: CoreSortOrder::Asc,
+        };
+        let n = home
+            .entries
+            .iter()
+            .filter(|e| filter.matches(e).0)
+            .count();
+        if n > 0 {
+            counts.insert(date, n);
+        }
+    }
+
+    // Highlight whatever period is currently active.  Falls back to no
+    // highlight when the string is empty or unparseable.
+    let selection = parse_period(home.period.trim())
+        .map(|p| month_grid::selection_from_period(&p))
+        .unwrap_or(Selection::None);
+
+    let counts_ref = &counts;
+    let resp = MonthGrid::new("home_calendar", &mut home.calendar_cursor)
+        .selection(selection)
+        .show_week_column(true)
+        .day_badge(&|d| counts_ref.get(&d).copied().unwrap_or(0))
+        .show(ui);
+
+    if let Some(d) = resp.day_clicked {
+        home.period = d.format("%Y-%m-%d").to_string();
+    } else if let Some(monday) = resp.week_clicked {
+        let (s, e) = week_bounds(monday);
+        home.period = format_period_range(s, e);
+    } else if let Some((y, m)) = resp.month_clicked {
+        let (s, e) = month_bounds(y, m);
+        home.period = format_period_range(s, e);
+    } else if resp.today_clicked {
+        home.period = "today".to_string();
+    } else if resp.clear_clicked {
+        home.period.clear();
+    }
+    ui.add_space(2.0);
+}
+
+/// Return the Monday at-or-before the 1st of the month containing `cursor` —
+/// matches the layout used by [`MonthGrid`] so we can pre-walk the grid here
+/// to compute badge counts.
+fn grid_start_for_month(cursor: NaiveDate) -> NaiveDate {
+    use chrono::Datelike as _;
+    let first = NaiveDate::from_ymd_opt(cursor.year(), cursor.month(), 1).unwrap();
+    let lead = first.weekday().num_days_from_monday() as i64;
+    first - Duration::days(lead)
+}
+
+/// Human-readable hint shown next to the calendar caret.  Best-effort —
+/// returns "All entries" when no period is set or the value can't be parsed.
+fn period_summary(period: &str) -> String {
+    let s = period.trim();
+    if s.is_empty() {
+        return "All entries".to_string();
+    }
+    match parse_period(s) {
+        Ok(Period::Range(start, end)) => {
+            let sd = start.date();
+            let ed = end.date();
+            if sd == ed {
+                sd.format("%Y-%m-%d").to_string()
+            } else {
+                format!("{} – {}", sd.format("%Y-%m-%d"), ed.format("%Y-%m-%d"))
+            }
+        }
+        Ok(Period::None) => "Unset field".to_string(),
+        Err(_) => s.to_string(),
+    }
+}
+
 // ── Editor panel ─────────────────────────────────────────────────────────────
 
 fn draw_editor_panel(app: &mut App, ui: &mut egui::Ui) {
@@ -806,11 +921,14 @@ fn draw_editor_panel_inner(home: &mut HomeState, ui: &mut egui::Ui) -> bool {
                         });
                         ui.vertical(|ui| {
                             ui.label("Due (YYYY-MM-DD)");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut editor.task_due)
-                                    .hint_text("2026-05-16")
-                                    .desired_width(160.0),
-                            );
+                            ui.horizontal(|ui| {
+                                ui.add(
+                                    egui::TextEdit::singleline(&mut editor.task_due)
+                                        .hint_text("2026-05-16")
+                                        .desired_width(140.0),
+                                );
+                                date_picker_button(ui, "task_due", &mut editor.task_due);
+                            });
                         });
                     });
                 }
@@ -824,17 +942,27 @@ fn draw_editor_panel_inner(home: &mut HomeState, ui: &mut egui::Ui) -> bool {
                     ui.horizontal(|ui| {
                         ui.vertical(|ui| {
                             ui.label("Start (YYYY-MM-DD)");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut editor.event_start)
-                                    .desired_width(160.0),
-                            );
+                            ui.horizontal(|ui| {
+                                ui.add(
+                                    egui::TextEdit::singleline(&mut editor.event_start)
+                                        .desired_width(140.0),
+                                );
+                                date_picker_button(
+                                    ui,
+                                    "event_start",
+                                    &mut editor.event_start,
+                                );
+                            });
                         });
                         ui.vertical(|ui| {
                             ui.label("End (YYYY-MM-DD)");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut editor.event_end)
-                                    .desired_width(160.0),
-                            );
+                            ui.horizontal(|ui| {
+                                ui.add(
+                                    egui::TextEdit::singleline(&mut editor.event_end)
+                                        .desired_width(140.0),
+                                );
+                                date_picker_button(ui, "event_end", &mut editor.event_end);
+                            });
                         });
                     });
                 }
@@ -1412,27 +1540,6 @@ fn tree_toggle(ui: &mut egui::Ui, src: egui::ImageSource<'static>) -> egui::Resp
         [TREE_TOGGLE_SIZE, TREE_TOGGLE_SIZE],
         egui::Button::image(img).frame(false),
     )
-}
-
-const PERIOD_OPTIONS: &[(&str, &str)] = &[
-    ("", "All"),
-    ("today", "Today"),
-    ("yesterday", "Yesterday"),
-    ("tomorrow", "Tomorrow"),
-    ("this_week", "This week"),
-    ("last_week", "Last week"),
-    ("next_week", "Next week"),
-    ("this_month", "This month"),
-    ("last_month", "Last month"),
-    ("next_month", "Next month"),
-];
-
-fn period_label(value: &str) -> &'static str {
-    PERIOD_OPTIONS
-        .iter()
-        .find(|(v, _)| *v == value)
-        .map(|(_, l)| *l)
-        .unwrap_or("All")
 }
 
 const SORT_OPTIONS: &[(&str, &str)] = &[

--- a/sapphire-journal-desktop/src/widgets/date_picker.rs
+++ b/sapphire-journal-desktop/src/widgets/date_picker.rs
@@ -1,0 +1,83 @@
+//! Calendar-popup date picker for `YYYY-MM-DD` text fields.
+//!
+//! Renders a small button next to the text input that toggles a popup
+//! containing [`MonthGrid`].  Selecting a day overwrites the buffer with
+//! the formatted date string.
+
+use chrono::NaiveDate;
+use eframe::egui;
+
+use super::month_grid::{MonthGrid, Selection};
+
+const DATE_FMT: &str = "%Y-%m-%d";
+
+/// Cursor (displayed month) for an open date-picker popup. Persisted in
+/// egui memory so the user's scroll position survives across frames.
+#[derive(Clone, Copy)]
+struct CursorMem(NaiveDate);
+
+/// Shows a "📅" button.  When clicked, opens a popup containing a month
+/// grid; clicking a day writes the formatted date into `buf`.
+pub fn date_picker_button(
+    ui: &mut egui::Ui,
+    id_salt: &str,
+    buf: &mut String,
+) -> egui::Response {
+    let button = ui.small_button("📅");
+    let popup_id = button.id.with(("date_picker", id_salt));
+
+    egui::Popup::from_toggle_button_response(&button)
+        .id(popup_id)
+        .close_behavior(egui::PopupCloseBehavior::CloseOnClickOutside)
+        .show(|ui| {
+            ui.set_min_width(220.0);
+
+            let parsed = NaiveDate::parse_from_str(buf.trim(), DATE_FMT).ok();
+            let today = chrono::Local::now().date_naive();
+
+            // Seed the cursor from the buffer, falling back to today.
+            // Subsequent month navigation persists in egui memory.
+            let cursor_key = popup_id.with("cursor");
+            let mut cursor = ui
+                .ctx()
+                .data_mut(|d| d.get_temp::<CursorMem>(cursor_key))
+                .map(|c| c.0)
+                .unwrap_or(parsed.unwrap_or(today));
+
+            let selection = parsed
+                .map(|d| Selection::Range(d, d))
+                .unwrap_or(Selection::None);
+
+            let resp = MonthGrid::new(id_salt, &mut cursor)
+                .selection(selection)
+                .show_week_column(false)
+                .cell_size(24.0)
+                .show(ui);
+
+            ui.ctx()
+                .data_mut(|d| d.insert_temp(cursor_key, CursorMem(cursor)));
+
+            let mut close = false;
+            if let Some(d) = resp.day_clicked {
+                *buf = d.format(DATE_FMT).to_string();
+                close = true;
+            }
+            if resp.today_clicked {
+                *buf = today.format(DATE_FMT).to_string();
+                close = true;
+            }
+            if resp.clear_clicked {
+                buf.clear();
+                close = true;
+            }
+            // Week / month clicks are ignored — a date picker selects a
+            // single day.  Those events are still surfaced by the widget
+            // for the home-screen filter use case.
+
+            if close {
+                egui::Popup::close_id(ui.ctx(), popup_id);
+            }
+        });
+
+    button
+}

--- a/sapphire-journal-desktop/src/widgets/mod.rs
+++ b/sapphire-journal-desktop/src/widgets/mod.rs
@@ -1,0 +1,2 @@
+pub mod date_picker;
+pub mod month_grid;

--- a/sapphire-journal-desktop/src/widgets/month_grid.rs
+++ b/sapphire-journal-desktop/src/widgets/month_grid.rs
@@ -1,0 +1,299 @@
+//! Reusable month-grid calendar widget.
+//!
+//! Used by the home screen's period filter (with the ISO week column and
+//! per-day entry-count dots) and by the date pickers in the entry editor
+//! (week column hidden, no badges).
+
+use chrono::{Datelike, Duration, NaiveDate};
+use eframe::egui;
+
+/// Highlighted range on the grid.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Selection {
+    #[default]
+    None,
+    /// Inclusive [start, end] range — used for week / month / explicit ranges.
+    Range(NaiveDate, NaiveDate),
+}
+
+impl Selection {
+    fn contains(&self, d: NaiveDate) -> bool {
+        match self {
+            Selection::None => false,
+            Selection::Range(s, e) => d >= *s && d <= *e,
+        }
+    }
+}
+
+/// One day's worth of UI extras: a click-count badge.
+pub type DayBadge<'a> = &'a dyn Fn(NaiveDate) -> usize;
+
+pub struct MonthGrid<'a> {
+    id_salt: &'a str,
+    /// Displayed month (driven by the prev/next arrows). The caller stores
+    /// this between frames; the widget mutates it when the user navigates.
+    cursor: &'a mut NaiveDate,
+    selection: Selection,
+    show_week_column: bool,
+    /// Optional closure returning the entry count for a given date. `0` →
+    /// no badge.
+    day_badge: Option<DayBadge<'a>>,
+    cell_size: f32,
+}
+
+impl<'a> MonthGrid<'a> {
+    pub fn new(id_salt: &'a str, cursor: &'a mut NaiveDate) -> Self {
+        Self {
+            id_salt,
+            cursor,
+            selection: Selection::None,
+            show_week_column: false,
+            day_badge: None,
+            cell_size: 28.0,
+        }
+    }
+
+    pub fn selection(mut self, sel: Selection) -> Self {
+        self.selection = sel;
+        self
+    }
+
+    pub fn show_week_column(mut self, show: bool) -> Self {
+        self.show_week_column = show;
+        self
+    }
+
+    pub fn day_badge(mut self, badge: DayBadge<'a>) -> Self {
+        self.day_badge = Some(badge);
+        self
+    }
+
+    pub fn cell_size(mut self, size: f32) -> Self {
+        self.cell_size = size;
+        self
+    }
+}
+
+// `MonthGridResponse` is currently used by callers via `MonthGrid::show`'s
+// return value rather than by name; re-exported through `mod.rs`.
+
+#[derive(Default, Debug)]
+pub struct MonthGridResponse {
+    pub day_clicked: Option<NaiveDate>,
+    /// Monday of the clicked ISO week.
+    pub week_clicked: Option<NaiveDate>,
+    /// (year, month) of the clicked month header.
+    pub month_clicked: Option<(i32, u32)>,
+    /// True when the user clicked the "Today" shortcut.
+    pub today_clicked: bool,
+    /// True when the user clicked the "Clear" shortcut.
+    pub clear_clicked: bool,
+}
+
+impl<'a> MonthGrid<'a> {
+    pub fn show(self, ui: &mut egui::Ui) -> MonthGridResponse {
+        let MonthGrid {
+            id_salt,
+            cursor,
+            selection,
+            show_week_column,
+            day_badge,
+            cell_size,
+        } = self;
+
+        let mut resp = MonthGridResponse::default();
+        let today = chrono::Local::now().date_naive();
+
+        // ── Header bar: month nav + Today + Clear ───────────────────────
+        ui.horizontal(|ui| {
+            if ui.small_button("◀").on_hover_text("Previous month").clicked() {
+                *cursor = add_months(*cursor, -1);
+            }
+            let label = format!("{} {}", month_name(cursor.month()), cursor.year());
+            let month_btn = ui
+                .add(egui::Button::new(egui::RichText::new(label).strong()).frame(false))
+                .on_hover_text("Filter by this month");
+            if month_btn.clicked() {
+                resp.month_clicked = Some((cursor.year(), cursor.month()));
+            }
+            if ui.small_button("▶").on_hover_text("Next month").clicked() {
+                *cursor = add_months(*cursor, 1);
+            }
+
+            ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                if ui.small_button("Clear").on_hover_text("Show all entries").clicked() {
+                    resp.clear_clicked = true;
+                }
+                if ui.small_button("Today").on_hover_text("Filter by today").clicked() {
+                    *cursor = today;
+                    resp.today_clicked = true;
+                }
+            });
+        });
+
+        // ── Day-of-week header ──────────────────────────────────────────
+        ui.add_space(2.0);
+        egui::Grid::new(format!("{id_salt}_dow"))
+            .num_columns(if show_week_column { 8 } else { 7 })
+            .min_col_width(cell_size)
+            .max_col_width(cell_size)
+            .spacing([2.0, 2.0])
+            .show(ui, |ui| {
+                if show_week_column {
+                    ui.weak("W");
+                }
+                for d in ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"] {
+                    ui.weak(d);
+                }
+                ui.end_row();
+            });
+
+        // ── 6 × 7 day grid ──────────────────────────────────────────────
+        let first_of_month = NaiveDate::from_ymd_opt(cursor.year(), cursor.month(), 1).unwrap();
+        // Walk back to the Monday at-or-before the 1st.
+        let lead = first_of_month.weekday().num_days_from_monday() as i64;
+        let grid_start = first_of_month - Duration::days(lead);
+
+        egui::Grid::new(format!("{id_salt}_grid"))
+            .num_columns(if show_week_column { 8 } else { 7 })
+            .min_col_width(cell_size)
+            .max_col_width(cell_size)
+            .spacing([2.0, 2.0])
+            .show(ui, |ui| {
+                for week in 0..6 {
+                    let week_monday = grid_start + Duration::days(week * 7);
+
+                    if show_week_column {
+                        let iso = week_monday.iso_week();
+                        let in_sel = (0..7).any(|i| {
+                            selection.contains(week_monday + Duration::days(i))
+                        });
+                        let txt = egui::RichText::new(format!("{:02}", iso.week())).weak();
+                        let btn = egui::Button::new(txt)
+                            .frame(false)
+                            .min_size(egui::vec2(cell_size, cell_size))
+                            .selected(in_sel);
+                        if ui.add(btn).on_hover_text("Filter by this week").clicked() {
+                            resp.week_clicked = Some(week_monday);
+                        }
+                    }
+
+                    for dow in 0..7 {
+                        let date = week_monday + Duration::days(dow);
+                        let in_current_month = date.month() == cursor.month();
+                        let is_today = date == today;
+                        let selected = selection.contains(date);
+
+                        let mut rt = egui::RichText::new(format!("{}", date.day()));
+                        if !in_current_month {
+                            rt = rt.weak();
+                        }
+                        if is_today {
+                            rt = rt.strong().underline();
+                        }
+
+                        let btn = egui::Button::new(rt)
+                            .min_size(egui::vec2(cell_size, cell_size))
+                            .selected(selected)
+                            .frame(in_current_month);
+                        let r = ui.add(btn);
+                        if r.clicked() {
+                            resp.day_clicked = Some(date);
+                        }
+
+                        // Entry-count dot (drawn over the button rect).
+                        if let Some(badge) = day_badge {
+                            let count = badge(date);
+                            if count > 0 {
+                                let painter = ui.painter_at(r.rect);
+                                let center = egui::pos2(
+                                    r.rect.right() - 4.0,
+                                    r.rect.bottom() - 4.0,
+                                );
+                                let color = if selected {
+                                    ui.visuals().selection.stroke.color
+                                } else {
+                                    ui.visuals().widgets.active.fg_stroke.color
+                                };
+                                painter.circle_filled(center, 2.5, color);
+                            }
+                        }
+                    }
+                    ui.end_row();
+                }
+            });
+
+        resp
+    }
+}
+
+fn month_name(m: u32) -> &'static str {
+    match m {
+        1 => "Jan",
+        2 => "Feb",
+        3 => "Mar",
+        4 => "Apr",
+        5 => "May",
+        6 => "Jun",
+        7 => "Jul",
+        8 => "Aug",
+        9 => "Sep",
+        10 => "Oct",
+        11 => "Nov",
+        12 => "Dec",
+        _ => "?",
+    }
+}
+
+/// Move `d` by `n` calendar months. Clamps the day to the last valid day
+/// of the target month (e.g. Jan 31 + 1mo → Feb 28/29).
+fn add_months(d: NaiveDate, n: i32) -> NaiveDate {
+    let total = d.year() * 12 + (d.month() as i32 - 1) + n;
+    let year = total.div_euclid(12);
+    let month = (total.rem_euclid(12) + 1) as u32;
+    let last = last_day_of_month(year, month);
+    NaiveDate::from_ymd_opt(year, month, d.day().min(last)).unwrap()
+}
+
+fn last_day_of_month(year: i32, month: u32) -> u32 {
+    let (ny, nm) = if month == 12 { (year + 1, 1u32) } else { (year, month + 1) };
+    let first_next = NaiveDate::from_ymd_opt(ny, nm, 1).unwrap();
+    (first_next - Duration::days(1)).day()
+}
+
+/// First-and-last-day pair for the given month — convenient for callers
+/// constructing a [`Selection::Range`] from a `(year, month)` click.
+pub fn month_bounds(year: i32, month: u32) -> (NaiveDate, NaiveDate) {
+    let first = NaiveDate::from_ymd_opt(year, month, 1).unwrap();
+    let last_day = last_day_of_month(year, month);
+    let last = NaiveDate::from_ymd_opt(year, month, last_day).unwrap();
+    (first, last)
+}
+
+/// ISO Monday → ISO Sunday range — convenient for callers responding to
+/// [`MonthGridResponse::week_clicked`].
+pub fn week_bounds(monday: NaiveDate) -> (NaiveDate, NaiveDate) {
+    (monday, monday + Duration::days(6))
+}
+
+/// `YYYY-MM-DD` → `YYYY-MM-DD` formatter used for period strings.
+pub fn format_period_range(start: NaiveDate, end: NaiveDate) -> String {
+    if start == end {
+        start.format("%Y-%m-%d").to_string()
+    } else {
+        format!("{}/{}", start.format("%Y-%m-%d"), end.format("%Y-%m-%d"))
+    }
+}
+
+/// Reverse of [`format_period_range`] — derive the highlight range from
+/// a `Period` parsed from the home state. Returns `None` when the period
+/// is `Period::None` or empty.
+pub fn selection_from_period(
+    period: &sapphire_journal_core::period::Period,
+) -> Selection {
+    use sapphire_journal_core::period::Period;
+    match period {
+        Period::None => Selection::None,
+        Period::Range(s, e) => Selection::Range(s.date(), e.date()),
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the Period combo box on the home screen with a month-grid calendar above the editor. Day / week (ISO Mon–Sun) / month clicks all set the active period filter; per-cell dots indicate whether any Bullet Journal-active entries fall on that day.
- Adds a shared `widgets/month_grid` widget. It's also reused by a new date-picker popup attached to the editor's `task.due`, `event_start`, and `event_end` text inputs — that variant hides the ISO week column and per-day badges, and writes the selected `YYYY-MM-DD` back into the buffer.
- "Today" and "Clear" shortcuts on the calendar header set `period = "today"` and empty, respectively. The caret toggles visibility (`HomeState::show_calendar`).
- Removes the now-unused `PERIOD_OPTIONS` / `period_label` constants from the sidebar.

## Notes
- The badge count for each visible day runs the same `FieldSelector::active()` filter as the entry list, so the dots match what clicking the day will actually show.
- `home.period` continues to be a `parse_period`-compatible string (`today`, `YYYY-MM-DD`, `YYYY-MM-DD/YYYY-MM-DD`), so the rest of the sort / filter pipeline is unchanged.
- Depends conceptually on #234 (also using `FieldSelector::active()` for the home period filter); independent file-wise so either order works.

## Test plan
- [ ] Open desktop app, see calendar above the editor with current month
- [ ] Click a day → list filters to that date, that cell is highlighted
- [ ] Click a week number → list filters to Mon–Sun, all 7 cells highlighted
- [ ] Click the month title → list filters to whole month
- [ ] Click "Today" → cursor jumps to today, period becomes `today`
- [ ] Click "Clear" → all entries visible again
- [ ] Edit an entry with a task: click 📅 next to Due, pick a date, confirm value populates the field
- [ ] Same for Event Start / Event End
- [ ] Caret beside "Calendar" collapses / expands the widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)