### PR TITLE
fix(desktop): adapt to git2 0.21 Remote::url API change

### DIFF
--- a/sapphire-journal-desktop/src/screens/settings_panel.rs
+++ b/sapphire-journal-desktop/src/screens/settings_panel.rs
@@ -56,7 +56,7 @@ impl SettingsPanelState {
             .and_then(|repo| {
                 repo.find_remote("origin")
                     .ok()
-                    .and_then(|r| r.url().map(str::to_owned))
+                    .and_then(|r| r.url().ok().map(str::to_owned))
             })
             .unwrap_or_default();
 


### PR DESCRIPTION
## Summary
- `git2` 0.21 changed `Remote::url()` from `Option<&str>` to `Result<&str, Error>`, breaking the workspace build after #233
- Convert the `Result` to `Option` via `.ok()` and keep the `.map(str::to_owned)` to preserve the prior owned-String semantics in `SettingsPanelState::open`

## Test plan
- [x] `cargo check -p sapphire-journal-desktop` passes locally
- [ ] CI passes
- [ ] Smoke test: open the desktop app's settings panel on a journal with a `origin` remote and confirm the URL field is populated