### PR TITLE
fix(desktop): surface sync errors and add timeout + busy indicator

### DIFF
--- a/sapphire-journal-desktop/src/app.rs
+++ b/sapphire-journal-desktop/src/app.rs
@@ -73,6 +73,9 @@ pub enum AppEvent {
     /// Sent by the periodic-sync task after a successful sync so the UI can
     /// reload entries that may have been added or modified by `git pull`.
     EntriesNeedReload,
+    /// Sent when the user-triggered "Sync now" task completes (or times out).
+    /// `Ok(())` triggers a reload; `Err(msg)` is surfaced as a home error banner.
+    SyncFinished(std::result::Result<(), String>),
 }
 
 pub struct App {
@@ -167,6 +170,10 @@ pub struct HomeState {
     pub confirm_delete_entry: bool,
     pub error_msg: Option<String>,
     pub info_msg: Option<String>,
+
+    /// `true` while a user-triggered "Sync now" task is running. Used to
+    /// short-circuit duplicate clicks and to render a spinner in the header.
+    pub sync_in_progress: bool,
 }
 
 impl HomeState {
@@ -192,6 +199,7 @@ impl HomeState {
             confirm_delete_entry: false,
             error_msg: None,
             info_msg: None,
+            sync_in_progress: false,
         }
     }
 }
@@ -255,7 +263,8 @@ impl App {
 
         // Periodic background sync: cache + retrieve refresh + git pull/push,
         // mirroring the cadence used by the MCP server.  Skips ticks when no
-        // journal is open.
+        // journal is open. Each tick runs on a blocking worker with a
+        // timeout so a hung libgit2 fetch can't stall every future tick.
         if let Some(interval) = UserConfig::load().ok().and_then(|c| c.sync_interval()) {
             let state_arc = Arc::clone(&journal_state);
             let tx = event_tx.clone();
@@ -265,27 +274,45 @@ impl App {
                 ticker.tick().await; // skip the immediate first tick
                 loop {
                     ticker.tick().await;
-                    let did_sync = {
-                        let guard = state_arc.lock().unwrap();
-                        match guard.as_ref() {
-                            Some(state) => {
-                                if let Err(e) = state.sync() {
-                                    let _ = tx.send(AppEvent::Error(format!(
-                                        "Periodic cache sync failed: {e}"
-                                    )));
-                                }
-                                if let Err(e) = state.git_sync() {
-                                    let _ = tx.send(AppEvent::Error(format!(
-                                        "Periodic git sync failed: {e}"
-                                    )));
-                                }
-                                true
-                            }
-                            None => false,
+                    let state_arc_inner = Arc::clone(&state_arc);
+                    let handle = tokio::task::spawn_blocking(move || {
+                        let guard = state_arc_inner.lock().unwrap();
+                        let Some(state) = guard.as_ref() else {
+                            return Ok::<bool, String>(false);
+                        };
+                        state.sync().map_err(|e| format!("cache sync: {e}"))?;
+                        state.git_sync().map_err(|e| format!("git sync: {e}"))?;
+                        Ok(true)
+                    });
+                    let outcome = tokio::time::timeout(
+                        std::time::Duration::from_secs(120),
+                        handle,
+                    )
+                    .await;
+                    match outcome {
+                        Ok(Ok(Ok(true))) => {
+                            let _ = tx.send(AppEvent::EntriesNeedReload);
                         }
-                    };
-                    if did_sync {
-                        let _ = tx.send(AppEvent::EntriesNeedReload);
+                        Ok(Ok(Ok(false))) => {
+                            // No journal open this tick — nothing to do.
+                        }
+                        Ok(Ok(Err(msg))) => {
+                            let _ = tx.send(AppEvent::Error(format!(
+                                "Periodic sync failed: {msg}"
+                            )));
+                        }
+                        Ok(Err(join_err)) => {
+                            let _ = tx.send(AppEvent::Error(format!(
+                                "Periodic sync task panicked: {join_err}"
+                            )));
+                        }
+                        Err(_elapsed) => {
+                            let _ = tx.send(AppEvent::Error(
+                                "Periodic sync timed out after 120s — \
+                                 git fetch may be hanging on SSH or network."
+                                    .to_string(),
+                            ));
+                        }
                     }
                     // Wake the UI thread so the event is processed promptly
                     // even if the window has no pending input.
@@ -409,7 +436,15 @@ impl App {
                     self.dialog = None;
                 }
                 AppEvent::Error(msg) => {
-                    self.error_msg = Some(msg);
+                    // Sync / journal-state errors are user-facing — show them
+                    // on the home banner when a journal is open so they're
+                    // not silently swallowed (the app-level banner only
+                    // renders on the journal-list screen).
+                    if let Some(home) = self.home.as_mut() {
+                        home.error_msg = Some(msg);
+                    } else {
+                        self.error_msg = Some(msg);
+                    }
                     self.dialog = None;
                 }
                 AppEvent::CleanupAndError {
@@ -423,6 +458,19 @@ impl App {
                 AppEvent::EntriesNeedReload => {
                     if let Some(home) = self.home.as_mut() {
                         home.needs_reload = true;
+                    }
+                }
+                AppEvent::SyncFinished(result) => {
+                    if let Some(home) = self.home.as_mut() {
+                        home.sync_in_progress = false;
+                        match result {
+                            Ok(()) => {
+                                home.needs_reload = true;
+                            }
+                            Err(msg) => {
+                                home.error_msg = Some(msg);
+                            }
+                        }
                     }
                 }
             }

--- a/sapphire-journal-desktop/src/screens/journal_home.rs
+++ b/sapphire-journal-desktop/src/screens/journal_home.rs
@@ -71,6 +71,14 @@ pub fn show(app: &mut App, ui: &mut egui::Ui, journal_id: Uuid) {
             ui.horizontal(|ui| {
                 draw_journal_switcher(app, ui, journal_id);
                 if let Some(home) = &app.home {
+                    if home.sync_in_progress {
+                        ui.add(egui::Spinner::new().size(14.0));
+                        ui.small("Syncing…");
+                        // While a sync is running, keep painting so the
+                        // spinner animates even without user input.
+                        ui.ctx()
+                            .request_repaint_after(std::time::Duration::from_millis(100));
+                    }
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         ui.small(home.journal_root.display().to_string());
                     });
@@ -1446,14 +1454,35 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
     }
 }
 
+/// Time budget for a single manual sync. libgit2 itself has no fetch
+/// timeout, so SSH/network hangs would otherwise stall the worker thread
+/// (and the `journal_state` mutex it holds) indefinitely. After this
+/// elapses we report a timeout error to the UI; the worker thread keeps
+/// running and will eventually release the lock when libgit2 finally
+/// errors out or completes.
+const MANUAL_SYNC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+
 /// Run cache + git sync once, off-thread, and report success/failure via
 /// `AppEvent`.  Lets the user verify sync independently of the 10-minute
 /// periodic tick.
 fn trigger_manual_sync(app: &mut App) {
+    // Guard against duplicate clicks: a previous Sync now may still be
+    // blocked on the journal_state mutex (e.g. libgit2 fetch hanging).
+    // Without this, every additional click leaks another tokio task that
+    // also waits forever on the same mutex.
+    if let Some(home) = app.home.as_mut() {
+        if home.sync_in_progress {
+            home.error_msg = Some("Sync already in progress".to_string());
+            return;
+        }
+        home.sync_in_progress = true;
+        home.error_msg = None;
+    }
+
     let state_arc = std::sync::Arc::clone(&app.journal_state);
     let tx = app.event_tx.clone();
     app.runtime.spawn(async move {
-        let result = tokio::task::spawn_blocking(move || {
+        let handle = tokio::task::spawn_blocking(move || {
             let guard = state_arc.lock().unwrap();
             let Some(state) = guard.as_ref() else {
                 return Err("no journal is open".to_string());
@@ -1461,23 +1490,21 @@ fn trigger_manual_sync(app: &mut App) {
             state.sync().map_err(|e| format!("cache sync: {e}"))?;
             state.git_sync().map_err(|e| format!("git sync: {e}"))?;
             Ok::<(), String>(())
-        })
-        .await;
-        match result {
-            Ok(Ok(())) => {
-                let _ = tx.send(crate::app::AppEvent::EntriesNeedReload);
-            }
-            Ok(Err(msg)) => {
-                let _ = tx.send(crate::app::AppEvent::Error(format!(
-                    "Sync failed: {msg}"
-                )));
-            }
-            Err(join_err) => {
-                let _ = tx.send(crate::app::AppEvent::Error(format!(
-                    "Sync task panicked: {join_err}"
-                )));
-            }
-        }
+        });
+
+        let outcome = match tokio::time::timeout(MANUAL_SYNC_TIMEOUT, handle).await {
+            Ok(Ok(inner)) => inner,
+            Ok(Err(join_err)) => Err(format!("Sync task panicked: {join_err}")),
+            Err(_elapsed) => Err(format!(
+                "Sync timed out after {}s — git fetch may be hanging on SSH or network. \
+                 Check that `git pull` works in this repo from the terminal.",
+                MANUAL_SYNC_TIMEOUT.as_secs()
+            )),
+        };
+
+        let _ = tx.send(crate::app::AppEvent::SyncFinished(
+            outcome.map_err(|msg| format!("Sync failed: {msg}")),
+        ));
     });
 }
 


### PR DESCRIPTION
## Summary

A libgit2 fetch hang or auth failure during \"Sync now\" was previously **invisible**:

- \`AppEvent::Error\` is only rendered on the journal-list screen — the home screen reads \`home.error_msg\` and ignored anything sent to \`app.error_msg\`.
- The worker thread held the \`journal_state\` mutex for the entire fetch. If libgit2 hung (slow network, ssh-agent prompt, dead host), every subsequent \"Sync now\" click queued up another tokio task that also waited forever on the same mutex — with no UI feedback in either direction.
- No fetch timeout existed anywhere in the stack, so a hung remote could stall **every** future periodic-sync tick too.

This PR makes failures visible and prevents the cascade:

- Route \`AppEvent::Error\` to \`home.error_msg\` when a journal is open so the existing red banner in the left sidebar surfaces sync failures.
- New \`AppEvent::SyncFinished(Result<(), String>)\` so the UI can clear the busy flag and trigger a reload exactly once.
- Wrap **both** manual and periodic syncs in \`tokio::time::timeout(120 s)\`. On timeout the worker thread keeps running, but the user gets an immediate error explaining the likely cause (\"git fetch may be hanging on SSH or network — check that \`git pull\` works in this repo from the terminal\").
- Add \`HomeState::sync_in_progress\` and short-circuit duplicate clicks with \"Sync already in progress\".
- Render a spinner + \"Syncing…\" in the top header while a manual sync runs, with \`request_repaint_after\` so it animates without user input.

## Test plan

- [ ] Click \"Sync now\" on a working remote → spinner + \"Syncing…\" appear; entries reload on success
- [ ] Click \"Sync now\" twice rapidly → second click shows \"Sync already in progress\" in the home banner
- [ ] Point the journal at a broken remote (e.g. unreachable host) and wait 120 s → timeout error appears in the home banner
- [ ] Force a sync error (bad credentials etc.) → error message is visible on the home screen, not silently swallowed

## Out of scope (follow-ups)

- Cancel the libgit2 worker thread itself on timeout (currently it keeps running and holds the mutex until libgit2 returns)
- HTTPS auth in the \`ssh_callbacks\` path
- Switch \`JournalState::open\` to \`open_configured\` so \`UserConfig.sync\` (remote name, backend kind) actually applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)