### PR TITLE
feat(desktop): swap tofu carets/📅 for lucide icons; brighten flag icons

### DIFF
--- a/sapphire-journal-desktop/src/icons.rs
+++ b/sapphire-journal-desktop/src/icons.rs
@@ -20,6 +20,7 @@ macro_rules! icon {
 // ── Toolbar / chrome ───────────────────────────────────────────────────────
 
 pub fn arrow_left() -> egui::ImageSource<'static> { icon!("arrow-left") }
+pub fn calendar() -> egui::ImageSource<'static> { icon!("calendar") }
 pub fn chevron_down() -> egui::ImageSource<'static> { icon!("chevron-down") }
 pub fn chevron_right() -> egui::ImageSource<'static> { icon!("chevron-right") }
 pub fn funnel() -> egui::ImageSource<'static> { icon!("funnel") }

--- a/sapphire-journal-desktop/src/screens/journal_home.rs
+++ b/sapphire-journal-desktop/src/screens/journal_home.rs
@@ -753,7 +753,7 @@ fn draw_entry_row(
         .show(ui, |ui| {
             ui.vertical(|ui| {
                 ui.horizontal(|ui| {
-                    let tint = ui.visuals().text_color();
+                    let tint = ui.visuals().strong_text_color();
                     for &flag in &header.flags {
                         ui.add(
                             egui::Image::new(icons::flag_icon(flag))
@@ -795,9 +795,16 @@ fn draw_home_calendar(app: &mut App, ui: &mut egui::Ui) {
 
     ui.add_space(2.0);
     ui.horizontal(|ui| {
-        let caret = if home.show_calendar { "▾" } else { "▸" };
+        let caret_src = if home.show_calendar {
+            icons::chevron_down()
+        } else {
+            icons::chevron_right()
+        };
+        let caret = egui::Image::new(caret_src)
+            .fit_to_exact_size(egui::vec2(14.0, 14.0))
+            .tint(ui.visuals().text_color());
         if ui
-            .add(egui::Button::new(format!("{caret} Calendar")).frame(false))
+            .add(egui::Button::image_and_text(caret, "Calendar").frame(false))
             .clicked()
         {
             home.show_calendar = !home.show_calendar;
@@ -1478,7 +1485,10 @@ fn draw_journal_switcher(app: &mut App, ui: &mut egui::Ui, current_id: Uuid) {
     let mut sync_now = false;
     let mut open_settings = false;
 
-    let response = ui.menu_button(format!("{current_name} ▾"), |ui| {
+    let caret = egui::Image::new(icons::chevron_down())
+        .fit_to_exact_size(egui::vec2(14.0, 14.0))
+        .tint(ui.visuals().text_color());
+    let response = ui.menu_button((current_name, caret), |ui| {
         if !others.is_empty() {
             ui.label("Other journals");
             for (id, name) in &others {

--- a/sapphire-journal-desktop/src/widgets/date_picker.rs
+++ b/sapphire-journal-desktop/src/widgets/date_picker.rs
@@ -7,6 +7,8 @@
 use chrono::NaiveDate;
 use eframe::egui;
 
+use crate::icons;
+
 use super::month_grid::{MonthGrid, Selection};
 
 const DATE_FMT: &str = "%Y-%m-%d";
@@ -16,14 +18,17 @@ const DATE_FMT: &str = "%Y-%m-%d";
 #[derive(Clone, Copy)]
 struct CursorMem(NaiveDate);
 
-/// Shows a "📅" button.  When clicked, opens a popup containing a month
-/// grid; clicking a day writes the formatted date into `buf`.
+/// Shows a calendar-icon button.  When clicked, opens a popup containing a
+/// month grid; clicking a day writes the formatted date into `buf`.
 pub fn date_picker_button(
     ui: &mut egui::Ui,
     id_salt: &str,
     buf: &mut String,
 ) -> egui::Response {
-    let button = ui.small_button("📅");
+    let icon = egui::Image::new(icons::calendar())
+        .fit_to_exact_size(egui::vec2(14.0, 14.0))
+        .tint(ui.visuals().text_color());
+    let button = ui.add(egui::Button::image(icon).small());
     let popup_id = button.id.with(("date_picker", id_salt));
 
     egui::Popup::from_toggle_button_response(&button)


### PR DESCRIPTION
## Summary

- Header carets `▾` / `▸` (next to "Journal" and "Calendar") rendered as tofu because U+25BE / U+25B8 are absent from both Ubuntu-Light (egui default) and the bundled NotoSansJP. Replaced with lucide `chevron-down` / `chevron-right` SVGs.
- Date-picker `📅` swapped to the lucide `calendar` SVG so chrome glyphs don't depend on the emoji-font fallback.
- Entry-row status (flag) icons were tinted with the dim `text_color()`, which read as washed-out next to the strong title — switched to `strong_text_color()` so they match the title.

User-typed emoji in entry bodies still falls through to egui's default `NotoEmoji-Regular` + `emoji-icon-font` (mono). The broader "should we bundle a color emoji font?" question is tracked separately in #242.

## Test plan
- [ ] `cargo build -p sapphire-journal-desktop` succeeds (verified locally)
- [ ] Launch desktop app; confirm:
  - [ ] No tofu next to the "Journal" dropdown in the top-left header
  - [ ] No tofu next to the "Calendar" toggle in the central panel
  - [ ] Calendar toggle's chevron flips between right/down on expand/collapse
  - [ ] Date-picker shows a calendar icon (not 📅) and the popup still works
  - [ ] Entry-row status icons are now as bright as the title text

🤖 Generated with [Claude Code](https://claude.com/claude-code)