### PR TITLE
chore(release-plz): re-enable auto-trigger for core only

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -4,11 +4,10 @@ permissions:
   pull-requests: write
   contents: write
 
-# Auto-trigger disabled until the missing crates have been manually
-# published to crates.io for the first time (see issue #225).
-# Re-enable by restoring `push: branches: [main]` once initial
-# publishes are done.
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,13 +12,16 @@ git_release_name = "core-v{{ version }}"
 name = "sapphire-journal-cli"
 git_tag_name = "cli-v{{ version }}"
 git_release_name = "cli-v{{ version }}"
+release = false
 
 [[package]]
 name = "sapphire-journal-mcp"
 git_tag_name = "mcp-v{{ version }}"
 git_release_name = "mcp-v{{ version }}"
+release = false
 
 [[package]]
 name = "sapphire-journal-desktop"
 git_tag_name = "desktop-v{{ version }}"
 git_release_name = "desktop-v{{ version }}"
+release = false


### PR DESCRIPTION
## Summary
- Restores `push: branches: [main]` trigger on the release-plz workflow so it runs automatically again.
- Adds `release = false` to `sapphire-journal-cli`, `sapphire-journal-mcp`, and `sapphire-journal-desktop` in `release-plz.toml` so release-plz fully skips them (no PR, no tag, no publish) — only `sapphire-journal-core` is processed for now.
- This is Step 1 of 3 toward resolving #225. The other crates will each be enabled in follow-up PRs after a manual first `cargo publish` (mcp next, then cli + desktop together).

## Why this is safe to merge now
The original failure was `package 'sapphire-journal-cli' not found in the registry, but the git tag cli-v0.11.1 exists.` Skipping cli/mcp/desktop entirely via `release = false` avoids that reconciliation path. `sapphire-journal-core` is already published at 0.11.1, so release-plz will only operate on a crate whose registry state already agrees with git.

## Test plan
- [ ] Confirm `secrets.CARGO_REGISTRY_TOKEN` is set at the repo level (needed by `release-plz-release` even when only `core` is managed).
- [ ] After merge, watch the first push-to-main run of the `Release-plz` workflow in Actions:
  - [ ] `release-plz-release` completes with no publish attempts logged for mcp/cli/desktop.
  - [ ] `release-plz-pr` either opens nothing (if no unreleased commits on core) or a PR titled like `chore: release sapphire-journal-core v0.11.x` touching only `sapphire-journal-core/`.
- [ ] Confirm no `cli-v*` / `mcp-v*` / `desktop-v*` tag is created and no release notes are drafted for those crates.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)