### PR TITLE
chore(release-plz): enable mcp and reset to 0.1.0 for initial release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7633,7 +7633,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal-mcp"
-version = "0.11.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -18,7 +18,6 @@ release = false
 name = "sapphire-journal-mcp"
 git_tag_name = "mcp-v{{ version }}"
 git_release_name = "mcp-v{{ version }}"
-release = false
 
 [[package]]
 name = "sapphire-journal-desktop"

--- a/sapphire-journal-cli/Cargo.toml
+++ b/sapphire-journal-cli/Cargo.toml
@@ -22,7 +22,7 @@ git-sync        = ["sapphire-journal-core/git-sync",        "sapphire-journal-mc
 [dependencies]
 clap.workspace = true
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.12.0", default-features = false, features = ["text-input"] }
-sapphire-journal-mcp  = { path = "../sapphire-journal-mcp",  version = "0.11.1", default-features = false }
+sapphire-journal-mcp  = { path = "../sapphire-journal-mcp",  version = "0.1.0", default-features = false }
 tokio = { workspace = true, features = ["rt"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/sapphire-journal-desktop/Cargo.toml
+++ b/sapphire-journal-desktop/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.12.0" }
-sapphire-journal-mcp  = { path = "../sapphire-journal-mcp",  version = "0.11.1", default-features = false, features = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync", "http-server"] }
+sapphire-journal-mcp  = { path = "../sapphire-journal-mcp",  version = "0.1.0", default-features = false, features = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync", "http-server"] }
 eframe = "0.34"
 egui = "0.34"
 egui_extras = { version = "0.34", features = ["svg"] }

--- a/sapphire-journal-mcp/Cargo.toml
+++ b/sapphire-journal-mcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sapphire-journal-mcp"
 edition.workspace = true
-version = "0.11.1"
+version = "0.1.0"
 description = "MCP server library for sapphire-journal"
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary
- Removes `release = false` from `sapphire-journal-mcp` in `release-plz.toml`, so release-plz starts managing it.
- Resets `sapphire-journal-mcp` version from `0.11.1` (legacy inherited shared version with cli/core) to `0.1.0`, marking this as the crate's first independent publish.
- Bumps the mcp dependency constraint in `sapphire-journal-cli/Cargo.toml` and `sapphire-journal-desktop/Cargo.toml` to `0.1.0` so the workspace continues to build.
- This is Step 2 of 3 toward closing #225. cli and desktop remain skipped via `release = false` and will be enabled in a follow-up PR.

## Expected behavior on merge
On the next push to main, the `release-plz-release` job will see `sapphire-journal-mcp` 0.1.0 with no matching `mcp-v*` tag and no entry on crates.io, and will:
- `cargo publish` mcp 0.1.0 to crates.io.
- Create the `mcp-v0.1.0` git tag and GitHub release.
- Create `sapphire-journal-mcp/CHANGELOG.md`.

This is fine because there is no tag/registry mismatch — the original #225 failure was specifically about the cli case where the tag existed but the registry entry didn't. For mcp, neither exists yet, so release-plz treats it as a normal first publish.

## Test plan
- [x] `cargo check --workspace` passes locally with the new version.
- [ ] After merge, watch the `Release-plz` workflow on main:
  - [ ] `release-plz-release` successfully publishes `sapphire-journal-mcp` 0.1.0 to crates.io.
  - [ ] `mcp-v0.1.0` tag and GitHub release are created.
  - [ ] cli and desktop release jobs remain skipped (no `cli-v*` / `desktop-v*` tag created).
- [ ] Verify on https://crates.io/crates/sapphire-journal-mcp that 0.1.0 is listed.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)