### PR TITLE
chore(release-plz): enable desktop and chain binary build via workflow_call

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1,0 +1,81 @@
+name: Release desktop binaries
+
+# Builds the cross-platform sapphire-journal-desktop binaries and
+# uploads them as release assets onto an existing GitHub release.
+#
+# Triggered as a reusable workflow from release-plz.yml (right after
+# the tag + release are created) plus workflow_dispatch for retroactive
+# uploads. `push: tags` is intentionally omitted because release-plz's
+# GITHUB_TOKEN tag pushes don't fire downstream workflows.
+#
+# The desktop crate is `publish = false`, so this workflow is the only
+# delivery path — users install via `gh release download`, not
+# `cargo install`.
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: 'Existing release tag to attach binaries to (e.g. desktop-v0.1.0).'
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: 'Existing release tag to attach binaries to (e.g. desktop-v0.1.0).'
+
+jobs:
+  build:
+    continue-on-error: ${{ matrix.continue-on-error }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            binary: sapphire-journal-desktop
+            asset_name: sapphire-journal-desktop-linux-x86_64
+            continue-on-error: false
+          - os: ubuntu-24.04-arm
+            binary: sapphire-journal-desktop
+            asset_name: sapphire-journal-desktop-linux-aarch64
+            continue-on-error: false
+          - os: macos-latest
+            binary: sapphire-journal-desktop
+            asset_name: sapphire-journal-desktop-macos-aarch64
+            continue-on-error: true
+          - os: windows-latest
+            binary: sapphire-journal-desktop.exe
+            asset_name: sapphire-journal-desktop-windows-x86_64.exe
+            continue-on-error: true
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc and GTK/WebKit deps (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler libgtk-3-dev libwebkit2gtk-4.1-dev libsoup-3.0-dev libjavascriptcoregtk-4.1-dev libxdo-dev
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        run: choco install protoc
+
+      - run: cargo build --release --package sapphire-journal-desktop
+
+      - name: Rename binary
+        shell: bash
+        run: cp target/release/${{ matrix.binary }} ${{ matrix.asset_name }}
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.tag }}
+          files: ${{ matrix.asset_name }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -17,6 +17,9 @@ jobs:
     concurrency:
       group: release-plz-release
       cancel-in-progress: false
+    outputs:
+      releases: ${{ steps.release.outputs.releases }}
+      releases_created: ${{ steps.release.outputs.releases_created }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -24,12 +27,46 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-      - uses: release-plz/action@v0.5.129
+      - id: release
+        uses: release-plz/action@v0.5.129
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Fan out to per-package binary build workflows. Each runs only when
+  # release-plz reported a release for that package on this push.
+  #
+  # Why this isn't done via `on: push: tags` in the build workflows:
+  # release-plz pushes the per-package tags using GITHUB_TOKEN, and
+  # GitHub Actions does not fire downstream workflows on tags pushed
+  # by GITHUB_TOKEN. workflow_call (this fan-out) is the cleanest way
+  # to chain the builds without provisioning a PAT.
+  parse-releases:
+    name: Parse release-plz output
+    needs: release-plz-release
+    if: needs.release-plz-release.outputs.releases_created == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      desktop_tag: ${{ steps.parse.outputs.desktop_tag }}
+    steps:
+      - id: parse
+        env:
+          RELEASES: ${{ needs.release-plz-release.outputs.releases }}
+        run: |
+          desktop_tag=$(jq -r '.[] | select(.package_name == "sapphire-journal-desktop") | .tag // empty' <<<"$RELEASES")
+          echo "desktop_tag=$desktop_tag" >> "$GITHUB_OUTPUT"
+
+  build-desktop:
+    name: Build sapphire-journal-desktop binaries
+    needs: parse-releases
+    if: needs.parse-releases.outputs.desktop_tag != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-desktop.yml
+    with:
+      tag: ${{ needs.parse-releases.outputs.desktop_tag }}
 
   release-plz-pr:
     name: Release-plz PR

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,8 +19,14 @@ name = "sapphire-journal-mcp"
 git_tag_name = "mcp-v{{ version }}"
 git_release_name = "mcp-v{{ version }}"
 
+# GitHub-release-only binary crate. `release = true` is load-bearing:
+# release-plz silently skips any crate whose Cargo.toml has
+# `publish = false` unless this is set, so without it no `desktop-v*`
+# tag or GH release would ever be created. See sapphire-agent's
+# release-plz.toml for the original write-up of this behaviour.
 [[package]]
 name = "sapphire-journal-desktop"
 git_tag_name = "desktop-v{{ version }}"
 git_release_name = "desktop-v{{ version }}"
-release = false
+publish = false
+release = true

--- a/sapphire-journal-desktop/Cargo.toml
+++ b/sapphire-journal-desktop/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 description.workspace = true
 license = "GPL-3.0-or-later"
 repository.workspace = true
+publish = false
 
 [dependencies]
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.12.0" }


### PR DESCRIPTION
## Summary
- Adds a fan-out from `release-plz.yml` to a new `release-desktop.yml` reusable workflow. release-plz pushes tags with `GITHUB_TOKEN`, and GitHub Actions does not fire downstream workflows on those tag pushes — so `workflow_call` (with a `workflow_dispatch` fallback) replaces `on: push: tags`.
- Enables `sapphire-journal-desktop` in release-plz with the `publish = false` + `release = true` pair: tag + GitHub release are managed by release-plz, but `cargo publish` is skipped (the crate ships only via GitHub Releases).
- `sapphire-journal-desktop/Cargo.toml` gets `publish = false` as the authoritative safety net.
- Pattern is lifted from `../sapphire-agent`.

This is Step 3a of the #225 rollout. CLI remains skipped via `release = false` and will be handled in a separate PR — its existing `cli-v0.11.1` tag without a matching crates.io entry needs the manual-tag + `workflow_dispatch` recovery path.

## Non-obvious bit
`release = true` on the desktop entry is **load-bearing**: release-plz silently skips any crate whose Cargo.toml has `publish = false` unless `release = true` is explicit in `release-plz.toml`. Without it, no `desktop-v*` tag or GitHub release would ever be created. Documented inline.

## Test plan
- [x] `cargo check -p sapphire-journal-desktop` passes locally.
- [x] `cargo publish -p sapphire-journal-desktop --dry-run` correctly refuses with `package.publish must be set to true`.
- [ ] After merge, watch the `Release-plz` workflow on main:
  - [ ] `release-plz-release` job runs and reports `releases_created=true` for desktop.
  - [ ] `parse-releases` extracts `desktop_tag=desktop-v0.1.0`.
  - [ ] `build-desktop` fires via `workflow_call`, builds binaries for all 4 targets, and uploads them to the `desktop-v0.1.0` GitHub release.
  - [ ] `cargo publish` is NOT attempted for desktop.
  - [ ] cli release job remains skipped (no `cli-v*` tag created).
- [ ] Verify the GitHub release page for `desktop-v0.1.0` has the 4 binary assets attached.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)