### PR TITLE
chore(release-plz): enable cli and refactor release-cli.yml to workflow_call

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,32 +1,60 @@
-name: Release CLI Binaries
+name: Release CLI binaries
 
+# Builds the cross-platform sapphire-journal-cli binaries and uploads
+# them as release assets onto an existing GitHub release.
+#
+# Triggered as a reusable workflow from release-plz.yml (right after
+# the tag + release are created) plus workflow_dispatch for retroactive
+# uploads / manual recovery. `push: tags` is intentionally omitted
+# because release-plz's GITHUB_TOKEN tag pushes don't fire downstream
+# workflows.
 on:
-  push:
-    tags:
-      - 'cli-v*'
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: 'Existing release tag to attach binaries to (e.g. cli-v0.11.1).'
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string
+        description: 'Existing release tag to attach binaries to (e.g. cli-v0.11.1).'
 
 jobs:
   build:
+    continue-on-error: ${{ matrix.continue-on-error }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             binary: sapphire-journal
             asset_name: sapphire-journal-linux-x86_64
-          - os: macos-latest
-            binary: sapphire-journal
-            asset_name: sapphire-journal-macos-aarch64
-          - os: windows-latest
-            binary: sapphire-journal.exe
-            asset_name: sapphire-journal-windows-x86_64.exe
+            continue-on-error: false
           - os: ubuntu-24.04-arm
             binary: sapphire-journal
             asset_name: sapphire-journal-linux-aarch64
+            continue-on-error: false
+          - os: macos-latest
+            binary: sapphire-journal
+            asset_name: sapphire-journal-macos-aarch64
+            continue-on-error: true
+          - os: windows-latest
+            binary: sapphire-journal.exe
+            asset_name: sapphire-journal-windows-x86_64.exe
+            continue-on-error: true
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
       - name: Install protoc (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -36,34 +64,15 @@ jobs:
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
         run: choco install protoc
-      - run: cargo build --release -p sapphire-journal-cli
 
-      - name: Rename binary (Unix)
-        if: runner.os != 'Windows'
+      - run: cargo build --release --package sapphire-journal-cli
+
+      - name: Rename binary
+        shell: bash
         run: cp target/release/${{ matrix.binary }} ${{ matrix.asset_name }}
 
-      - name: Rename binary (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: Copy-Item target/release/${{ matrix.binary }} ${{ matrix.asset_name }}
-
-      - uses: actions/upload-artifact@v7
+      - name: Upload to release
+        uses: softprops/action-gh-release@v3
         with:
-          name: ${{ matrix.asset_name }}
-          path: ${{ matrix.asset_name }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.ref_name }}
-          files: artifacts/*
+          tag_name: ${{ inputs.tag }}
+          files: ${{ matrix.asset_name }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -49,14 +49,29 @@ jobs:
     if: needs.release-plz-release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
     outputs:
+      cli_tag: ${{ steps.parse.outputs.cli_tag }}
       desktop_tag: ${{ steps.parse.outputs.desktop_tag }}
     steps:
       - id: parse
         env:
           RELEASES: ${{ needs.release-plz-release.outputs.releases }}
         run: |
+          cli_tag=$(jq -r '.[] | select(.package_name == "sapphire-journal-cli") | .tag // empty' <<<"$RELEASES")
           desktop_tag=$(jq -r '.[] | select(.package_name == "sapphire-journal-desktop") | .tag // empty' <<<"$RELEASES")
-          echo "desktop_tag=$desktop_tag" >> "$GITHUB_OUTPUT"
+          {
+            echo "cli_tag=$cli_tag"
+            echo "desktop_tag=$desktop_tag"
+          } >> "$GITHUB_OUTPUT"
+
+  build-cli:
+    name: Build sapphire-journal-cli binaries
+    needs: parse-releases
+    if: needs.parse-releases.outputs.cli_tag != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-cli.yml
+    with:
+      tag: ${{ needs.parse-releases.outputs.cli_tag }}
 
   build-desktop:
     name: Build sapphire-journal-desktop binaries

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,7 +12,6 @@ git_release_name = "core-v{{ version }}"
 name = "sapphire-journal-cli"
 git_tag_name = "cli-v{{ version }}"
 git_release_name = "cli-v{{ version }}"
-release = false
 
 [[package]]
 name = "sapphire-journal-mcp"


### PR DESCRIPTION
## Summary
Mirrors the desktop pattern from PR #248 for cli:
- `release-cli.yml` is refactored from `on: push: tags` to `workflow_call` + `workflow_dispatch`, taking `tag` as input. Collapses the previous build → release two-stage into a single matrix job that uploads each binary directly via `softprops/action-gh-release`.
- `release-plz.yml`'s `parse-releases` now also extracts `cli_tag`, and a new `build-cli` job fans out to `release-cli.yml` when cli is released.
- `release-plz.toml` drops `release = false` from `sapphire-journal-cli` so release-plz starts managing it.

This is Step 3b (the last step) of the #225 rollout.

## ⚠️ Heads-up — manual recovery likely required on first release

The existing `cli-v0.11.1` git tag does NOT have a matching crates.io entry (the crate was renamed from `sapphire-journal` and was never published under the new name). When release-plz next runs against main, the `release-plz-release` job will likely hit the original #225 error:

> package \`sapphire-journal-cli\` not found in the registry, but the git tag cli-v0.11.1 exists.

### Recovery path
1. Manually publish the current version to crates.io to reconcile registry with the orphan tag:
   ```sh
   cargo publish -p sapphire-journal-cli
   ```
   (Should publish at 0.11.1 from the current Cargo.toml — the existing tag points to the same code so no version conflict.)
2. Re-run the `Release-plz` workflow via `workflow_dispatch`.
3. If a fresh release is desired afterwards (e.g. version bump to 0.12.0 to match core), let release-plz propose it through its normal release-PR flow.

For ad-hoc binary uploads to an existing release, `release-cli.yml` now supports `workflow_dispatch` directly — pass the tag (e.g. `cli-v0.11.1`) and it'll build and attach binaries to that GitHub release.

## Test plan
- [ ] After merge, watch the `Release-plz` workflow run.
- [ ] If `release-plz-release` fails with the expected tag/registry mismatch error, perform the recovery steps above.
- [ ] After recovery, verify `cargo search sapphire-journal-cli` shows 0.11.1.
- [ ] On a future release-PR merge for cli, verify the `build-cli` fan-out fires and uploads the 4 binary assets to the new GitHub release.
- [ ] (Independent verification) Run `release-cli.yml` via `workflow_dispatch` with `tag=cli-v0.11.1` to retroactively populate that release with binaries.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)