### PR TITLE
chore(release): bump sapphire-journal-cli to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7577,7 +7577,7 @@ dependencies = [
 
 [[package]]
 name = "sapphire-journal-cli"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/sapphire-journal-cli/Cargo.toml
+++ b/sapphire-journal-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sapphire-journal-cli"
 edition.workspace = true
-version = "0.11.1"
+version = "0.12.0"
 description.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary
Bumps `sapphire-journal-cli` from `0.11.1` to `0.12.0` (the first independently-versioned cli release after the rename from `sapphire-journal`, aligning with the recent `sapphire-journal-core` 0.12.0). No other crate depends on cli, so this is a one-line change in `cli/Cargo.toml` plus the matching `Cargo.lock` entry.

`cargo check -p sapphire-journal-cli` passes locally.

## Why a bare version bump (no release-plz)
release-plz cannot auto-publish cli here because the orphan `cli-v0.11.1` git tag has no matching crates.io entry — release-plz's tag/registry reconciliation refuses to proceed (#225). The reusable `release-cli.yml` (refactored in #250) provides the manual recovery path via `workflow_dispatch`.

## Post-merge manual steps
After this PR is merged, the maintainer will:

```sh
# 1. Tag the merge commit
git fetch origin
git tag cli-v0.12.0 origin/main
git push origin cli-v0.12.0

# 2. Publish to crates.io
cargo publish -p sapphire-journal-cli

# 3. Trigger binary builds + GitHub release attachment
gh workflow run release-cli.yml -f tag=cli-v0.12.0
```

The `release-cli.yml` workflow uses `softprops/action-gh-release@v3` which auto-creates the GitHub release if it doesn't already exist, so step 3 covers both release creation and binary attachment.

## Test plan
- [x] `cargo check -p sapphire-journal-cli` passes.
- [ ] Verify `crates.io/crates/sapphire-journal-cli` shows 0.12.0 after manual publish.
- [ ] Verify `cli-v0.12.0` GitHub release has all 4 platform binaries attached.

Refs #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)