### PR TITLE
ci: add cargo-deny license and advisory check

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,27 @@
+name: cargo-deny
+
+# License compatibility, advisory (RUSTSEC) scanning, banned crates, and
+# unknown-source checks. The weekly schedule catches newly-filed advisories
+# against deps that haven't changed.
+
+on:
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/cargo-deny.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,75 @@
+# cargo-deny config. Run locally with `cargo deny check`.
+# Reference: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Restrict the dep graph to the platforms we actually publish binaries for
+# (see release-cli.yml / release-desktop.yml). This drops UEFI/WASM-only
+# transitive deps like `r-efi` so we don't need to allow their licenses.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+
+[advisories]
+yanked = "warn"
+# Transitive `unmaintained` advisories we can't act on without replacing
+# major deps (lance/lancedb, image/rav1e, git2, lindera). Re-evaluate when
+# those crates' upstreams move off the unmaintained package, or when a
+# *vulnerability* (not just unmaintained) advisory is filed for any of them.
+ignore = [
+    { id = "RUSTSEC-2025-0141", reason = "bincode 2.x is unmaintained but used transitively via lindera → lance; no safe upgrade exists." },
+    { id = "RUSTSEC-2026-0105", reason = "core2 is unmaintained and yanked but pulled in via image → rav1e → bitstream-io." },
+    { id = "RUSTSEC-2021-0153", reason = "encoding crate is unmaintained but pulled in via lindera → lance." },
+    { id = "RUSTSEC-2025-0119", reason = "number_prefix is unmaintained but pulled in via indicatif → hf-hub → fastembed." },
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained but pulled in via many proc-macro consumers; no drop-in replacement." },
+]
+
+[licenses]
+# Permissive SPDX identifiers actually present in the resolved graph.
+# Re-survey with `cargo deny list --layout license` before widening.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "NCSA",
+    "OFL-1.1",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.93
+
+# Per-crate carve-outs for licenses we don't want to globally allow.
+exceptions = [
+    # Our own GPL-3.0-or-later desktop crate (with App Store exception, see
+    # sapphire-journal-desktop/LICENSE.App-Store-Exception). Scoping it here
+    # prevents other GPL-3.0 deps from silently slipping in.
+    { name = "sapphire-journal-desktop", allow = ["GPL-3.0-or-later"] },
+    # `epaint_default_fonts` ships the Ubuntu font under the Ubuntu Font
+    # Licence 1.0 — fine for redistribution but not worth globally allowing.
+    { name = "epaint_default_fonts", allow = ["Ubuntu-font-1.0"] },
+]
+
+[bans]
+# Duplicate-version warnings are too noisy in real Rust workspaces (every
+# transitively-pulled `syn`/`bitflags`/`hashbrown` version trips it).
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

Adds cargo-deny to the workspace with a tuned config and a dedicated GitHub Actions workflow that runs on PRs touching Cargo metadata, on push to main, and on a weekly schedule. The weekly run catches newly-filed RUSTSEC advisories against deps that haven't otherwise changed.

This was discussed as a follow-up to #252.

### `deny.toml` highlights

- **Target filtering** — \`[graph] targets\` restricts analysis to the four platforms in release-cli.yml / release-desktop.yml (Linux x86_64/aarch64, macOS aarch64, Windows x86_64). Filters out UEFI-only transitive deps like \`r-efi\` (LGPL-2.1) so they don't need to be globally allowed.
- **License allowlist** — explicit enumeration of the permissive SPDX IDs actually present in the resolved graph. Widening requires re-surveying via \`cargo deny list --layout license\`, which keeps the allowlist a conscious decision rather than drift.
- **Per-crate license exceptions:**
  - \`sapphire-journal-desktop\` — GPL-3.0-or-later (our own crate with the App Store marketplace exception); scoping it per-crate prevents other GPL-3.0 deps from silently slipping in.
  - \`epaint_default_fonts\` — Ubuntu-font-1.0 (just the bundled Ubuntu font).
- **\`multiple-versions = "allow"\`** — duplicate-version noise is unavoidable in real Rust workspaces; CVEs are what we actually care about here.

### Ignored advisories (all \`unmaintained\`, no vulnerabilities)

All five are transitive deps via crates we can't easily replace. Each entry has a reason field so the next contributor knows why it's ignored:

| ID | Crate | Path |
|---|---|---|
| RUSTSEC-2025-0141 | bincode 2.x | lindera → lance |
| RUSTSEC-2026-0105 | core2 | image → rav1e → bitstream-io |
| RUSTSEC-2021-0153 | encoding | lindera → lance |
| RUSTSEC-2025-0119 | number_prefix | indicatif → hf-hub → fastembed |
| RUSTSEC-2024-0436 | paste | many proc-macro consumers |

Vulnerability advisories (the \`vulnerability\` severity) continue to fail the build by default.

### Verified locally

\`\`\`
\$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
\`\`\`

## Test plan

- [ ] CI \`cargo-deny\` job passes on this PR
- [ ] Confirm the scheduled run fires on Monday 06:00 UTC after merge
- [ ] If a future PR adds a dep with a new SPDX identifier, confirm the check fails with a useful diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)