### PR TITLE
fix(mcp): use EmptyObject for zero-arg tool input schemas

### DIFF
--- a/sapphire-journal-mcp/src/server.rs
+++ b/sapphire-journal-mcp/src/server.rs
@@ -498,9 +498,14 @@ impl SapphireJournalServer {
         .map_err(|e| e.to_string())
     }
 
+    // Zero-argument tools use `Parameters<EmptyObject>` rather than
+    // `Parameters<serde_json::Value>`: the latter renders as `{"title":"AnyValue"}`
+    // with no top-level `type`, which strict MCP clients reject — Anthropic returns
+    // `tools.<N>.custom.input_schema.type: Field required` (400).
+    // See https://github.com/fluo10/sapphire-agent/issues/155.
     #[tool(description = "Run a full git sync cycle: commit staged changes, fetch and merge from \
         remote, then push. No-op when no git repository is found or sync is disabled.")]
-    fn git_sync(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
+    fn git_sync(&self, _: Parameters<EmptyObject>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             self.with_state(|s| {
                 if !s.has_sync_backend() {
@@ -514,7 +519,7 @@ impl SapphireJournalServer {
     }
 
     #[tool(description = "Show cache location, schema version, and entry/tag counts.")]
-    fn cache_info(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
+    fn cache_info(&self, _: Parameters<EmptyObject>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             self.with_state(|s| {
                 let info = s.cache_info()?;
@@ -535,7 +540,7 @@ impl SapphireJournalServer {
     #[tool(description = "Incrementally sync the cache with the current journal state. \
         Re-indexes files whose mtime has changed and removes entries for deleted files. \
         Returns the number of entries in the cache after sync.")]
-    fn cache_sync(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
+    fn cache_sync(&self, _: Parameters<EmptyObject>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             self.with_state(|s| {
                 s.sync()?;
@@ -550,7 +555,7 @@ impl SapphireJournalServer {
         Use this after updating sapphire-journal when the schema has changed, \
         or when the cache has become inconsistent. \
         Returns the number of entries indexed.")]
-    fn cache_rebuild(&self, _: Parameters<serde_json::Value>) -> Result<String, String> {
+    fn cache_rebuild(&self, _: Parameters<EmptyObject>) -> Result<String, String> {
         (|| -> anyhow::Result<String> {
             let mut guard = self.state.lock().unwrap();
             let journal_root = guard.journal.root.clone();
@@ -735,4 +740,46 @@ pub async fn run(journal_dir: Option<&Path>, init: bool) -> anyhow::Result<()> {
     let service = server.serve(stdio()).await?;
     service.waiting().await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Zero-argument tools use `EmptyObject`, which must advertise a top-level `type: object`.
+    /// `serde_json::Value` used to render as `{"title":"AnyValue"}` (no `type`), which Anthropic
+    /// rejects with `tools.<N>.custom.input_schema.type: Field required`. See
+    /// https://github.com/fluo10/sapphire-agent/issues/155.
+    #[test]
+    fn empty_object_schema_has_object_type() {
+        let schema = schemars::schema_for!(EmptyObject);
+        let value = serde_json::to_value(&schema).unwrap();
+
+        assert_eq!(
+            value.get("type").and_then(|t| t.as_str()),
+            Some("object"),
+            "EmptyObject schema must declare type=object, got: {value}"
+        );
+        // Must not regress to the schemaless `serde_json::Value` shape.
+        assert_ne!(
+            value.get("title").and_then(|t| t.as_str()),
+            Some("AnyValue"),
+            "EmptyObject must not render as the schemaless AnyValue shape"
+        );
+    }
+
+    /// Guard the generated input schema for every registered tool so a future tool added
+    /// with `Parameters<serde_json::Value>` can't silently reintroduce the missing-`type` bug.
+    #[test]
+    fn all_tool_input_schemas_declare_object_type() {
+        for tool in SapphireJournalServer::tool_router().list_all() {
+            let schema = &tool.input_schema;
+            assert_eq!(
+                schema.get("type").and_then(|t| t.as_str()),
+                Some("object"),
+                "tool `{}` input_schema must declare type=object, got: {schema:?}",
+                tool.name,
+            );
+        }
+    }
 }


### PR DESCRIPTION
## 背景

sapphire-agent を MCP クライアントとして sapphire-journal-cli と連携した際に [fluo10/sapphire-agent#155](https://github.com/fluo10/sapphire-agent/issues/155) が発生した。

引数なしツール（`git_sync` / `cache_info` / `cache_sync` / `cache_rebuild`）が引数型に `Parameters<serde_json::Value>` を使っており、schemars が生成するスキーマが以下のようにトップレベル `type` を欠いていた:

```json
{ "$schema": "https://json-schema.org/draft/2020-12/schema", "title": "AnyValue" }
```

Anthropic は `tools[].input_schema.type` を必須とするため、このスキーマが 1 つでも混ざるとターン全体が `tools.<N>.custom.input_schema.type: Field required` の 400 で落ち、毎回 fallback プロバイダに切り替わっていた。これは sapphire-agent#155 の「Out of scope」で上流（本リポジトリ）側の修正候補として挙げられていた問題。

## 変更内容

- 引数なし 4 ツールの引数型を `Parameters<serde_json::Value>` → rmcp 提供の `Parameters<EmptyObject>` に変更。`EmptyObject` は `{"type":"object", ...}` を正しく出力し、`#[serde(deny_unknown_fields)]` で余計なプロパティも拒否する
- 経緯がわかるよう issue リンク付きのコメントを追記
- ユニットテストを 2 件追加:
  - `empty_object_schema_has_object_type` — `EmptyObject` のスキーマが `type: object` を持ち `AnyValue` に退行しないことを検証
  - `all_tool_input_schemas_declare_object_type` — rmcp ルーターが登録する全ツールの `input_schema`（ワイヤー上で送られるスキーマそのもの）が `type: object` を持つことを検証。将来 `Parameters<serde_json::Value>` で同じバグが再発するのを防ぐガード

## テスト

```
test server::tests::empty_object_schema_has_object_type ... ok
test server::tests::all_tool_input_schemas_declare_object_type ... ok
test result: ok. 2 passed; 0 failed
```

## Related

- fluo10/sapphire-agent#155 — クライアント側のサニタイズ対応は別リポジトリの issue 本体（必要なら別途対応可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)