### PR TITLE
feat!: depend on sapphire-framework and drop the SQLite retrieve backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +466,7 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "flatbuffers",
- "lz4_flex",
+ "lz4_flex 0.13.1",
  "zstd",
 ]
 
@@ -1064,6 +1073,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
+dependencies = [
+ "darling 0.20.11",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,6 +1248,12 @@ checksum = "6d910bedd62c24733263d0bed247460853c9d22e8956bd4cd964302095e04e90"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cfg-if"
@@ -2580,6 +2620,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,6 +3071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
 name = "fastembed"
 version = "5.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3261,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3630,6 +3692,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3711,6 +3775,12 @@ name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -4552,7 +4622,7 @@ dependencies = [
  "half",
  "hex",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rand_xoshiro",
  "random_word",
 ]
@@ -4682,7 +4752,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "rand 0.9.2",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rangemap",
  "rayon",
  "roaring",
@@ -4959,6 +5029,12 @@ name = "lebe"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lexical-core"
@@ -5304,6 +5380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5327,6 +5412,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "lz4_flex"
@@ -5422,6 +5513,15 @@ name = "md5"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
+]
 
 [[package]]
 name = "memchr"
@@ -5565,6 +5665,12 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "naga"
@@ -6192,6 +6298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "onig"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6328,6 +6440,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -6922,6 +7043,8 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -6931,7 +7054,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -6944,6 +7067,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6961,6 +7094,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -6976,6 +7112,16 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "rand_distr"
@@ -7049,7 +7195,7 @@ dependencies = [
  "paste",
  "profiling",
  "rand 0.9.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
  "v_frame",
@@ -7134,6 +7280,15 @@ checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
 dependencies = [
  "bytemuck",
  "font-types",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -7576,6 +7731,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "sapphire-framework-retrieve"
+version = "0.1.0"
+source = "git+https://github.com/fluo10/sapphire-framework?branch=feat%2Fframework-migration#5b5d82666fa632faca15c52e5d13eab219f2cb4f"
+dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "fastembed",
+ "futures",
+ "lancedb",
+ "redb",
+ "serde",
+ "serde_json",
+ "tantivy",
+ "thiserror 2.0.18",
+ "tokio",
+ "ureq 3.3.0",
+]
+
+[[package]]
+name = "sapphire-framework-sync"
+version = "0.1.0"
+source = "git+https://github.com/fluo10/sapphire-framework?branch=feat%2Fframework-migration#5b5d82666fa632faca15c52e5d13eab219f2cb4f"
+dependencies = [
+ "chrono",
+ "dirs 5.0.1",
+ "git2",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "sapphire-framework-track"
+version = "0.1.0"
+source = "git+https://github.com/fluo10/sapphire-framework?branch=feat%2Fframework-migration#5b5d82666fa632faca15c52e5d13eab219f2cb4f"
+dependencies = [
+ "redb",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "sapphire-framework-workspace"
+version = "0.1.0"
+source = "git+https://github.com/fluo10/sapphire-framework?branch=feat%2Fframework-migration#5b5d82666fa632faca15c52e5d13eab219f2cb4f"
+dependencies = [
+ "chrono",
+ "indexmap 2.14.0",
+ "md-5 0.11.0",
+ "sapphire-framework-retrieve",
+ "sapphire-framework-sync",
+ "sapphire-framework-track",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
 name = "sapphire-journal-cli"
 version = "0.12.0"
 dependencies = [
@@ -7599,7 +7818,8 @@ dependencies = [
  "grain-id",
  "indexmap 2.14.0",
  "rusqlite",
- "sapphire-workspace",
+ "sapphire-framework-track",
+ "sapphire-framework-workspace",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -7648,62 +7868,6 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "sapphire-retrieve"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db3b019c8de4021a8d661bbbff8c8eb1aeecec9478bb6565692e2099faf5de6"
-dependencies = [
- "arrow-array",
- "arrow-schema",
- "fastembed",
- "futures",
- "lancedb",
- "rusqlite",
- "serde",
- "serde_json",
- "sqlite-vec",
- "thiserror 2.0.18",
- "tokio",
- "ureq 3.3.0",
-]
-
-[[package]]
-name = "sapphire-sync"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1c9300843a424d37a2e9c7bec068ed26a841c2e78e2cc86d76e72fc28b9cb7"
-dependencies = [
- "chrono",
- "dirs 5.0.1",
- "git2",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "sapphire-workspace"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65dda79c6f01969a9386e7b61f7edc216c50c27d1a017abaca61497a1b8dfa37"
-dependencies = [
- "chrono",
- "indexmap 2.14.0",
- "md-5 0.11.0",
- "sapphire-retrieve",
- "sapphire-sync",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "toml",
- "tracing",
- "uuid",
- "walkdir",
 ]
 
 [[package]]
@@ -8032,6 +8196,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "skrifa"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8216,15 +8389,6 @@ dependencies = [
  "nom 7.1.3",
  "serde",
  "unicode-segmentation",
-]
-
-[[package]]
-name = "sqlite-vec"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ba424237a9a5db2f6071f193319e2b6a32f7f3961debb2fbbfe67067abce3f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -8439,6 +8603,152 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tantivy"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs 2.0.2",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "hyperloglogplus",
+ "itertools 0.14.0",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex 0.11.6",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
+dependencies = [
+ "downcast-rs 2.0.2",
+ "fastdivide",
+ "itertools 0.14.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
+dependencies = [
+ "nom 7.1.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
+dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
+dependencies = [
+ "murmurhash32",
+ "rand_distr 0.4.3",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "tap"
@@ -9375,7 +9685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
- "downcast-rs",
+ "downcast-rs 1.2.1",
  "rustix 1.1.4",
  "scoped-tls",
  "smallvec",

--- a/docs/config/user-config.toml
+++ b/docs/config/user-config.toml
@@ -10,8 +10,8 @@
 
 # ── Retrieve cache ───────────────────────────────────────────────────────────
 [cache.retrieve]
-# "none" | "sqlite_vec" | "lancedb"
-db = "sqlite_vec"
+# "none" | "redb" | "lancedb"
+db = "redb"
 
 # How often to refresh the retrieve cache (full-text + vector index).
 # Omit or set to 0 to disable periodic refresh.

--- a/sapphire-journal-cli/Cargo.toml
+++ b/sapphire-journal-cli/Cargo.toml
@@ -13,8 +13,8 @@ name = "sapphire-journal"
 path = "src/main.rs"
 
 [features]
-default = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync"]
-sqlite-store    = ["sapphire-journal-core/sqlite-store",   "sapphire-journal-mcp/sqlite-store"]
+default = ["redb-store", "fastembed-embed", "git-sync"]
+redb-store      = ["sapphire-journal-core/redb-store",      "sapphire-journal-mcp/redb-store"]
 lancedb-store   = ["sapphire-journal-core/lancedb-store",  "sapphire-journal-mcp/lancedb-store"]
 fastembed-embed = ["sapphire-journal-core/fastembed-embed", "sapphire-journal-mcp/fastembed-embed"]
 git-sync        = ["sapphire-journal-core/git-sync",        "sapphire-journal-mcp/git-sync"]

--- a/sapphire-journal-cli/src/commands/cache.rs
+++ b/sapphire-journal-cli/src/commands/cache.rs
@@ -92,18 +92,18 @@ fn info(journal: &Journal) -> Result<()> {
 
         match user_cfg.cache.retrieve.db {
             VectorDb::None => {}
-            VectorDb::SqliteVec => {
+            VectorDb::Redb => {
                 if embed_cfg.dimension.is_some() {
                     state.load_retrieve_backend(&user_cfg).map_err(anyhow::Error::msg)?;
                     match state.retrieve_db().vec_info() {
                         Ok(vi) => {
-                            println!("vector backend: sqlite_vec (dim={})", vi.embedding_dim);
+                            println!("vector backend: redb (dim={})", vi.embedding_dim);
                             println!("vectors:        {} indexed, {} pending", vi.vector_count, vi.pending_count);
                         }
                         Err(e) => eprintln!("warn: could not read vector stats: {e}"),
                     }
                 } else {
-                    println!("vector backend: sqlite_vec (dimension not configured)");
+                    println!("vector backend: redb (dimension not configured)");
                 }
             }
             #[cfg(feature = "lancedb-store")]

--- a/sapphire-journal-cli/src/commands/entry.rs
+++ b/sapphire-journal-cli/src/commands/entry.rs
@@ -531,7 +531,7 @@ fn new(state: &JournalState, fields: EntryFields) -> Result<()> {
     state.sync()?;
     let dest = ops::create_entry(state, fields.into())?;
     if let Ok(conn) = state.open_conn() {
-        let _ = cache::upsert_entry_from_path(&conn, &dest, state.retrieve_db());
+        let _ = cache::upsert_entry_from_path(&conn, &dest, state.retrieve_db(), state.track());
     }
     let _ = state.on_file_updated(&dest);
     println!("created: {}", dest.display());
@@ -558,7 +558,7 @@ fn edit(path: &Path, state: &JournalState) -> Result<()> {
         None           => { println!("updated: {}", path.display()); path.to_path_buf() }
     };
     if let Ok(conn) = state.open_conn() {
-        let _ = cache::upsert_entry_from_path(&conn, &final_path, state.retrieve_db());
+        let _ = cache::upsert_entry_from_path(&conn, &final_path, state.retrieve_db(), state.track());
     }
     if renamed.is_some() {
         let _ = state.on_file_deleted(path);
@@ -586,7 +586,7 @@ fn edit_new(state: &JournalState) -> Result<()> {
         None           => { println!("created: {}", path.display()); path.clone() }
     };
     if let Ok(conn) = state.open_conn() {
-        let _ = cache::upsert_entry_from_path(&conn, &final_path, state.retrieve_db());
+        let _ = cache::upsert_entry_from_path(&conn, &final_path, state.retrieve_db(), state.track());
     }
     if renamed.is_some() {
         let _ = state.on_file_deleted(&path);
@@ -621,12 +621,12 @@ fn set(state: &JournalState, path: &Path, fields: EntryFields, no_parent: bool) 
     }
     let new_path_opt = ops::update_entry(path, &conn, core_fields)?;
     if let Some(new_path) = new_path_opt {
-        let _ = cache::upsert_entry_from_path(&conn, &new_path, state.retrieve_db());
+        let _ = cache::upsert_entry_from_path(&conn, &new_path, state.retrieve_db(), state.track());
         let _ = state.on_file_deleted(path);
         let _ = state.on_file_updated(&new_path);
         println!("updated and renamed: {}", new_path.display());
     } else {
-        let _ = cache::upsert_entry_from_path(&conn, path, state.retrieve_db());
+        let _ = cache::upsert_entry_from_path(&conn, path, state.retrieve_db(), state.track());
         let _ = state.on_file_updated(path);
         println!("updated: {}", path.display());
     }
@@ -655,7 +655,7 @@ fn fix(state: &JournalState, entry: &str) -> Result<()> {
     match ops::fix_entry(&path)? {
         Some(new_path) => {
             if let Ok(conn) = state.open_conn() {
-                let _ = cache::upsert_entry_from_path(&conn, &new_path, state.retrieve_db());
+                let _ = cache::upsert_entry_from_path(&conn, &new_path, state.retrieve_db(), state.track());
             }
             let _ = state.on_file_deleted(&path);
             let _ = state.on_file_updated(&new_path);
@@ -701,7 +701,7 @@ fn remove(state: &JournalState, entry: &str) -> Result<()> {
     let path = resolve_entry(state, entry)?;
     ops::remove_entry(&path)?;
     if let Ok(conn) = state.open_conn() {
-        let _ = cache::remove_from_cache(&conn, &path, state.retrieve_db());
+        let _ = cache::remove_from_cache(&conn, &path, state.retrieve_db(), state.track());
     }
     let _ = state.on_file_deleted(&path);
     println!("removed: {}", path.display());

--- a/sapphire-journal-core/Cargo.toml
+++ b/sapphire-journal-core/Cargo.toml
@@ -9,8 +9,9 @@ categories = ["text-processing", "filesystem", "data-structures"]
 keywords = ["markdown", "task-management", "notes", "frontmatter", "plain-text"]
 
 [features]
-default = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync"]
-sqlite-store    = ["sapphire-workspace/sqlite-store"]
+default = ["redb-store", "fastembed-embed", "git-sync"]
+# Pure-Rust cache backend (redb + tantivy). Default; no SQLite/libsqlite3-sys.
+redb-store      = ["sapphire-workspace/redb-store"]
 lancedb-store   = ["sapphire-workspace/lancedb-store"]
 fastembed-embed = ["sapphire-workspace/fastembed-embed"]
 git-sync        = ["sapphire-workspace/git-sync"]
@@ -31,6 +32,8 @@ serde_json.workspace = true
 schemars.workspace = true
 uuid = { version = "1", features = ["v4", "serde"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
-sapphire-workspace = { version = "0.12.1", default-features = false }
+sapphire-workspace = { package = "sapphire-framework-workspace", git = "https://github.com/fluo10/sapphire-framework", branch = "feat/framework-migration", default-features = false }
+# mtime change-detection, split out of the retrieve store in framework PR #75.
+sapphire-track = { package = "sapphire-framework-track", git = "https://github.com/fluo10/sapphire-framework", branch = "feat/framework-migration" }
 grain-id = { version = "0.15", features = ["serde", "rusqlite", "schemars"] }
 dirs = { workspace = true }

--- a/sapphire-journal-core/src/cache.rs
+++ b/sapphire-journal-core/src/cache.rs
@@ -33,6 +33,7 @@ use std::{
 
 use grain_id::GrainId;
 use rusqlite::{params, Connection, OptionalExtension as _};
+use sapphire_track::TrackStore;
 use sapphire_workspace::RetrieveDb;
 
 use crate::{
@@ -114,11 +115,15 @@ pub struct CacheInfo {
 }
 
 /// Collect cache statistics for display.
-pub fn cache_info(journal: &Journal, conn: &Connection, retrieve: &RetrieveDb) -> Result<CacheInfo> {
+pub fn cache_info(
+    journal: &Journal,
+    conn: &Connection,
+    track: &dyn TrackStore,
+) -> Result<CacheInfo> {
     let db_path = db_path(&journal.cache_dir()?);
     let schema_version =
         conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i32>(0))?;
-    let file_count = retrieve.file_count()?;
+    let file_count = track.count()?;
     let entry_count =
         conn.query_row("SELECT COUNT(*) FROM entries", [], |row| row.get::<_, i64>(0))? as u64;
     let unique_tag_count =
@@ -168,6 +173,7 @@ pub fn sync_cache(
     journal: &Journal,
     conn: &Connection,
     retrieve: &RetrieveDb,
+    track: &dyn TrackStore,
 ) -> Result<()> {
     let disk_files = collect_with_mtime(journal)?;
     let disk_paths: HashSet<String> = disk_files
@@ -175,7 +181,7 @@ pub fn sync_cache(
         .map(|(p, _)| p.to_string_lossy().into_owned())
         .collect();
 
-    let db_files = retrieve.file_mtimes()?;
+    let db_files = track.mtimes()?;
 
     conn.execute_batch("PRAGMA defer_foreign_keys=ON; BEGIN")?;
 
@@ -192,7 +198,7 @@ pub fn sync_cache(
                 )
                 .ok();
             conn.execute("DELETE FROM entries WHERE path = ?1", [db_path])?;
-            let _ = retrieve.remove_file(db_path);
+            let _ = track.remove(db_path);
             if let Some(id) = entry_id {
                 let _ = retrieve.remove_document(id);
             }
@@ -212,13 +218,13 @@ pub fn sync_cache(
                     let entry = increment_until_free(conn, entry)?;
                     let final_mtime = file_mtime(&entry.path)?;
                     let final_str = entry.path.to_string_lossy();
-                    let _ = retrieve.upsert_file(final_str.as_ref(), final_mtime);
+                    let _ = track.upsert(final_str.as_ref(), final_mtime);
                     upsert_entry(conn, &entry)?;
                     let doc = entry_to_document(&entry);
                     let _ = retrieve.upsert_document(&doc);
                 }
                 Err(e) => {
-                    let _ = retrieve.upsert_file(path_str.as_ref(), *mtime);
+                    let _ = track.upsert(path_str.as_ref(), *mtime);
                     conn.execute(
                         "DELETE FROM entries WHERE path = ?1",
                         [path_str.as_ref()],
@@ -406,6 +412,7 @@ pub fn remove_from_cache(
     conn: &Connection,
     path: &Path,
     retrieve: &RetrieveDb,
+    track: &dyn TrackStore,
 ) -> Result<()> {
     let path_str = path.to_string_lossy();
 
@@ -418,7 +425,7 @@ pub fn remove_from_cache(
         .ok();
 
     conn.execute("DELETE FROM entries WHERE path = ?1", [path_str.as_ref()])?;
-    let _ = retrieve.remove_file(path_str.as_ref());
+    let _ = track.remove(path_str.as_ref());
 
     if let Some(id) = entry_id {
         let _ = retrieve.remove_document(id);
@@ -435,12 +442,13 @@ pub fn upsert_entry_from_path(
     conn: &Connection,
     path: &Path,
     retrieve: &RetrieveDb,
+    track: &dyn TrackStore,
 ) -> Result<()> {
     let entry = read_entry(path)?;
     let entry = increment_until_free(conn, entry)?;
     let mtime = file_mtime(&entry.path)?;
     let path_str = entry.path.to_string_lossy();
-    retrieve.upsert_file(path_str.as_ref(), mtime)?;
+    track.upsert(path_str.as_ref(), mtime)?;
     upsert_entry(conn, &entry)?;
     let doc = entry_to_document(&entry);
     let _ = retrieve.upsert_document(&doc);

--- a/sapphire-journal-core/src/error.rs
+++ b/sapphire-journal-core/src/error.rs
@@ -44,6 +44,14 @@ pub enum Error {
     #[error("cache error: {0}")]
     Cache(#[from] rusqlite::Error),
 
+    /// Failure from the framework's pure-Rust retrieve backend (redb/tantivy).
+    #[error("retrieve cache error: {0}")]
+    RetrieveCache(String),
+
+    /// Failure from the mtime change-detection store.
+    #[error("track store error: {0}")]
+    Track(#[from] sapphire_track::Error),
+
     #[error("embedding error: {0}")]
     Embed(String),
 
@@ -64,8 +72,10 @@ pub type Result<T> = std::result::Result<T, Error>;
 impl From<sapphire_workspace::RetrieveError> for Error {
     fn from(e: sapphire_workspace::RetrieveError) -> Self {
         match e {
-            #[cfg(feature = "sqlite-store")]
-            sapphire_workspace::RetrieveError::Sqlite(e) => Error::Cache(e),
+            #[cfg(feature = "redb-store")]
+            sapphire_workspace::RetrieveError::Redb(s) => Error::RetrieveCache(s),
+            #[cfg(feature = "redb-store")]
+            sapphire_workspace::RetrieveError::Tantivy(s) => Error::RetrieveCache(s),
             sapphire_workspace::RetrieveError::Embed(s) => Error::Embed(s),
             sapphire_workspace::RetrieveError::Io(e) => Error::Io(e),
             sapphire_workspace::RetrieveError::SchemaTooNew { db_version, app_version } => {

--- a/sapphire-journal-core/src/journal.rs
+++ b/sapphire-journal-core/src/journal.rs
@@ -181,17 +181,20 @@ impl Journal {
 
     /// Path to the retrieve database (FTS + vector index) for this journal.
     ///
-    /// Resolves to `{cache_dir}/retrieve_v1.db`.
+    /// Resolves to `{cache_dir}/retrieve.db`. The redb backend derives its own
+    /// store directory (`retrieve.redb/`) from this path.
     pub fn retrieve_db_path(&self) -> Result<PathBuf> {
-        #[cfg(feature = "sqlite-store")]
-        {
-            use sapphire_workspace::RETRIEVE_SCHEMA_VERSION;
-            return Ok(self.cache_dir()?.join(format!("retrieve_v{}.db", RETRIEVE_SCHEMA_VERSION)));
-        }
-        #[cfg(not(feature = "sqlite-store"))]
         Ok(self.cache_dir()?.join("retrieve.db"))
     }
 
+    /// Path to the mtime change-detection store for this journal.
+    ///
+    /// The filename is versioned so an incompatible redb format bump orphans
+    /// the old file rather than failing to open; the store is a rebuildable
+    /// cache.
+    pub fn track_db_path(&self) -> Result<PathBuf> {
+        Ok(self.cache_dir()?.join("track_v1.redb"))
+    }
 }
 
 fn collect_md_in(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {

--- a/sapphire-journal-core/src/journal_state.rs
+++ b/sapphire-journal-core/src/journal_state.rs
@@ -33,6 +33,8 @@ pub struct JournalState {
     pub journal: Journal,
     /// Always-present retrieve database (FTS + optional vector backend).
     retrieve_db: RetrieveDb,
+    /// mtime snapshot used to detect which files changed since the last sync.
+    track: sapphire_track::RedbTrackStore,
     embedder: OnceCell<Option<Box<dyn Embedder + Send + Sync>>>,
     /// Optional sync backend (e.g. git) for staging file changes and running
     /// periodic sync cycles.
@@ -49,9 +51,11 @@ impl JournalState {
         let conn = cache::open_cache(&journal)?;
         drop(conn);
         let retrieve_db = RetrieveDb::open(&journal.retrieve_db_path()?)?;
+        let track = sapphire_track::open_redb(&journal.track_db_path()?)?;
         let mut state = Self {
             journal,
             retrieve_db,
+            track,
             embedder: OnceCell::new(),
             sync_backend: None,
         };
@@ -72,9 +76,15 @@ impl JournalState {
             use sapphire_workspace::lancedb_store;
             let _ = std::fs::remove_dir_all(lancedb_store::data_dir(&journal.cache_dir()?));
         }
+        // Drop the mtime snapshot too: a stale snapshot paired with a freshly
+        // emptied retrieve index would make changed files look unchanged.
+        let track_path = journal.track_db_path()?;
+        let _ = std::fs::remove_file(&track_path);
+        let track = sapphire_track::open_redb(&track_path)?;
         let mut state = Self {
             journal,
             retrieve_db,
+            track,
             embedder: OnceCell::new(),
             sync_backend: None,
         };
@@ -95,12 +105,17 @@ impl JournalState {
         &self.retrieve_db
     }
 
+    /// Borrow the mtime change-detection store.
+    pub fn track(&self) -> &dyn sapphire_track::TrackStore {
+        &self.track
+    }
+
     /// Incrementally sync the cache with the current on-disk journal state.
     ///
     /// Also syncs documents into the retrieve database (FTS index).
     pub fn sync(&self) -> Result<()> {
         let conn = self.open_conn()?;
-        cache::sync_cache(&self.journal, &conn, &self.retrieve_db)
+        cache::sync_cache(&self.journal, &conn, &self.retrieve_db, &self.track)
     }
 
     /// Sync the cache and, when embedding is enabled, embed any pending chunks.
@@ -109,7 +124,7 @@ impl JournalState {
     /// disabled or nothing was pending).
     pub async fn sync_and_embed(&self, config: &UserConfig) -> Result<usize> {
         let conn = self.open_conn()?;
-        cache::sync_cache(&self.journal, &conn, &self.retrieve_db)?;
+        cache::sync_cache(&self.journal, &conn, &self.retrieve_db, &self.track)?;
         drop(conn);
 
         let embed_cfg = config.cache.retrieve.embedding.as_ref();
@@ -129,7 +144,7 @@ impl JournalState {
     /// Return cache statistics (path, schema version, entry count, etc.).
     pub fn cache_info(&self) -> Result<cache::CacheInfo> {
         let conn = self.open_conn()?;
-        cache::cache_info(&self.journal, &conn, &self.retrieve_db)
+        cache::cache_info(&self.journal, &conn, &self.track)
     }
 
     // ── vector backend ────────────────────────────────────────────────────────
@@ -169,12 +184,12 @@ impl JournalState {
     fn init_vector_backend(&self, vector_db: VectorDb, dim: u32) -> Result<()> {
         match vector_db {
             VectorDb::None => {}
-            VectorDb::SqliteVec => {
-                #[cfg(feature = "sqlite-store")]
-                self.retrieve_db.init_sqlite_vec(dim)?;
-                #[cfg(not(feature = "sqlite-store"))]
+            VectorDb::Redb => {
+                #[cfg(feature = "redb-store")]
+                self.retrieve_db.init_redb_vec(dim)?;
+                #[cfg(not(feature = "redb-store"))]
                 return Err(crate::error::Error::InvalidConfig(
-                    "sqlite-vec support is not compiled in (enable the `sqlite-store` feature)".into(),
+                    "redb support is not compiled in (enable the `redb-store` feature)".into(),
                 ));
             }
             #[cfg(feature = "lancedb-store")]

--- a/sapphire-journal-core/src/ops.rs
+++ b/sapphire-journal-core/src/ops.rs
@@ -529,7 +529,7 @@ pub fn list_entries(
     filter: &EntryFilter,
 ) -> Result<Vec<(EntryHeader, Vec<MatchFlag>)>> {
     if let Ok(conn) = state.open_conn() {
-        let _ = cache::sync_cache(&state.journal, &conn, state.retrieve_db());
+        let _ = cache::sync_cache(&state.journal, &conn, state.retrieve_db(), state.track());
         if let Ok(entries) = cache::list_entries_from_cache(&conn) {
             return apply_filter_and_sort(entries, filter);
         }

--- a/sapphire-journal-core/src/user_config.rs
+++ b/sapphire-journal-core/src/user_config.rs
@@ -102,7 +102,7 @@ impl UserConfig {
             .ok()
             .and_then(|v| match v.as_str() {
                 "none" => Some(VectorDb::None),
-                "sqlite_vec" => Some(VectorDb::SqliteVec),
+                "redb" => Some(VectorDb::Redb),
                 "lancedb" => Some(VectorDb::LanceDb),
                 _ => None,
             });

--- a/sapphire-journal-desktop/Cargo.toml
+++ b/sapphire-journal-desktop/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 sapphire-journal-core = { path = "../sapphire-journal-core", version = "0.12.0" }
-sapphire-journal-mcp  = { path = "../sapphire-journal-mcp",  version = "0.1.0", default-features = false, features = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync", "http-server"] }
+sapphire-journal-mcp  = { path = "../sapphire-journal-mcp",  version = "0.1.0", default-features = false, features = ["redb-store", "fastembed-embed", "git-sync", "http-server"] }
 eframe = "0.34"
 egui = "0.34"
 egui_extras = { version = "0.34", features = ["svg"] }

--- a/sapphire-journal-mcp/Cargo.toml
+++ b/sapphire-journal-mcp/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["markdown", "task-management", "notes", "mcp"]
 path = "src/lib.rs"
 
 [features]
-default = ["sqlite-store", "lancedb-store", "fastembed-embed", "git-sync"]
-sqlite-store = ["sapphire-journal-core/sqlite-store"]
+default = ["redb-store", "fastembed-embed", "git-sync"]
+redb-store = ["sapphire-journal-core/redb-store"]
 lancedb-store = ["sapphire-journal-core/lancedb-store"]
 fastembed-embed = ["sapphire-journal-core/fastembed-embed"]
 git-sync = ["sapphire-journal-core/git-sync"]

--- a/sapphire-journal-mcp/src/server.rs
+++ b/sapphire-journal-mcp/src/server.rs
@@ -362,7 +362,7 @@ impl SapphireJournalServer {
                 s.sync()?;
                 let dest = ops::create_entry(s, fields)?;
                 if let Ok(conn) = s.open_conn() {
-                    let _ = cache::upsert_entry_from_path(&conn, &dest, s.retrieve_db());
+                    let _ = cache::upsert_entry_from_path(&conn, &dest, s.retrieve_db(), s.track());
                 }
                 let _ = s.on_file_updated(&dest);
                 Ok(format!("created: {}", dest.display()))
@@ -410,13 +410,13 @@ impl SapphireJournalServer {
                 let conn = s.open_conn()?;
                 let path = ops::resolve_entry(&p.entry, &conn)?;
                 let msg = if let Some(new_path) = ops::update_entry(&path, &conn, fields)? {
-                    let _ = cache::upsert_entry_from_path(&conn, &new_path, s.retrieve_db());
+                    let _ = cache::upsert_entry_from_path(&conn, &new_path, s.retrieve_db(), s.track());
                     // File was renamed: remove old path and stage new path
                     let _ = s.on_file_deleted(&path);
                     let _ = s.on_file_updated(&new_path);
                     format!("updated and renamed: {}", new_path.display())
                 } else {
-                    let _ = cache::upsert_entry_from_path(&conn, &path, s.retrieve_db());
+                    let _ = cache::upsert_entry_from_path(&conn, &path, s.retrieve_db(), s.track());
                     let _ = s.on_file_updated(&path);
                     format!("updated: {}", path.display())
                 };
@@ -490,7 +490,7 @@ impl SapphireJournalServer {
                 let conn = s.open_conn()?;
                 let path = ops::resolve_entry(&p.entry, &conn)?;
                 ops::remove_entry(&path)?;
-                let _ = cache::remove_from_cache(&conn, &path, s.retrieve_db());
+                let _ = cache::remove_from_cache(&conn, &path, s.retrieve_db(), s.track());
                 let _ = s.on_file_deleted(&path);
                 Ok(format!("removed: {}", path.display()))
             })


### PR DESCRIPTION
Part of fluo10/sapphire-framework#80. Companion to fluo10/sapphire-framework#81.

Moves the workspace dependency onto the `sapphire-framework-*` crates and the retrieve cache onto the pure-Rust redb + tantivy backend.

## What changed

The dependency uses Cargo's `package =` alias, so **the extern name `sapphire_workspace` is unchanged** and no call sites move for that reason alone.

**The SQLite retrieve backend is gone**, because the framework removed it outright (fluo10/sapphire-framework#81 explains why: Cargo resolves optional deps even when their feature is off, so the framework's unactivated rusqlite still collided with grain-id's on `links = "sqlite3"`, and no single pinned version satisfied both journal and agent). journal keeps its own rusqlite for the entries/tags cache and grain-id, so `cargo tree -i libsqlite3-sys` now shows that single lineage instead of two conflicting ones.

**mtime tracking moved to `sapphire-track`.** The framework split change-detection out of `RetrieveDb` (framework #75), so the old `file_mtimes` / `upsert_file` / `remove_file` / `file_count` calls are gone. `sync_cache`, `remove_from_cache`, `upsert_entry_from_path` and `cache_info` now take a `&dyn TrackStore`, and `JournalState` owns a `RedbTrackStore` next to the retrieve DB. `rebuild` drops the mtime snapshot as well — a stale snapshot paired with a freshly emptied index would make changed files look unchanged.

Defaults across core/mcp/cli/desktop move from `sqlite-store, lancedb-store` to `redb-store`.

## Breaking changes

- `db = "sqlite_vec"` must become `db = "redb"` (the documented example config is updated). **No migration path from an existing SQLite retrieve cache** — it is rebuildable from the markdown files, which are the source of truth.
- `Error::Cache` still wraps `rusqlite::Error` for journal's own cache; framework backend failures surface as the new `Error::RetrieveCache(String)`.

## Verification

- `cargo check --workspace` → green.
- `cargo test --workspace` → all pass.
- `cargo tree -i libsqlite3-sys` → single lineage (grain-id / journal's own `cache.rs`), no framework-side rusqlite.

## Blocked on

**Do not merge before fluo10/sapphire-framework#81.** The framework dependency is a git dependency on `feat/framework-migration` until the crates are published, so **sapphire-journal cannot be published to crates.io while this is in place**. Once the framework crates are on crates.io, this should be swapped to a version dependency.

## Known remaining work

journal still carries rusqlite: `cache.rs` (entries/tags) is unconverted, and grain-id is pulled with its `rusqlite` feature. Dropping SQLite from journal entirely needs both — tracked in fluo10/sapphire-framework#80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
